### PR TITLE
Remove Pry from Gemfile as it is already present in gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,3 @@ gemspec
 
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
-
-group :development, :test do
-  gem 'pry'
-end


### PR DESCRIPTION
Repeat of #1 
Pry is added as a development dependency in active_storage_validations.gemspec, as well as in the Gemfile, which leads to the following command line warning message upon running bundle install
```
Your Gemfile lists the gem pry (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of one of them later.
```
This Pull Request removes Pry from the Gemfile.
Gemfile.lock has not changed.