### PR TITLE
Include validators lazily 

### DIFF
--- a/lib/active_storage_validations.rb
+++ b/lib/active_storage_validations.rb
@@ -4,7 +4,6 @@ require 'active_storage_validations/attached_validator'
 require 'active_storage_validations/content_type_validator'
 require 'active_storage_validations/size_validator'
 
-
-
-
-ActiveRecord::Base.send :include, ActiveStorageValidations
+ActiveSupport.on_load(:active_record) do
+  self.send :include, ActiveStorageValidations
+end


### PR DESCRIPTION
Include validators lazily once ActiveRecord::Base is loaded by using ActiveSupport.on_load hook. It prevents an eager initialization of ActiveRecord by this gem.

In my case it was leading to a crash if run `rails assets:precompile` inside a Dockerfile. I added this gem and it triggered initialization of ActiveRecord::Base. The latter was crashing when it tried to configure a connection to a database. It was happing, because DATABASE_URL is not defined during the docker build phase (and is not supposed to be defined). 

I understand that my case can be very specific, but in the same time this fix can be helpful for someone else. Are there any possible downsides for lazy loading?