### PR TITLE
Missing file: check the blob exists

### DIFF
--- a/lib/active_storage_validations/content_type_validator.rb
+++ b/lib/active_storage_validations/content_type_validator.rb
@@ -30,7 +30,7 @@ module ActiveStorageValidations
     end
 
     def content_type(file)
-      file.blob.content_type
+      file.blob.present? && file.blob.content_type
     end
 
     def content_type_valid?(file)


### PR DESCRIPTION

I got the error when the file is missing from the arguments.
```
NoMethodError: undefined method `content_type' for nil:NilClass
from [...]ruby/gems/2.5.0/gems/active_storage_validations-0.5.1/lib/active_storage_validations/content_type_validator.rb:33:in `content_type'
```

It's define [line 32](https://github.com/igorkasyanchuk/active_storage_validations/blob/master/lib/active_storage_validations/content_type_validator.rb#L32)
```
    def content_type(file)
      file.blob.content_type
    end
```

`content_type_valid?` does check the blob before accessing it.
```
    def content_type_valid?(file)
      file.blob.present? && file.blob.content_type.in?(types)
    end
```

Do the same check, solve the issue and the error shown is "File has an invalid content type". Could/should be "missing file" but I'm not sure how to it.