### PR TITLE
Declare image_processing optional dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,14 +55,10 @@ GEM
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     erubi (1.8.0)
-    ffi (1.10.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    image_processing (1.9.0)
-      mini_magick (>= 4.9.3, < 5)
-      ruby-vips (>= 2.0.13, < 3)
     jaro_winkler (1.5.2)
     loofah (2.2.3)
       crass (~> 1.0.2)
@@ -125,8 +121,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
-    ruby-vips (2.0.13)
-      ffi (~> 1.9)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -149,7 +143,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_storage_validations!
-  image_processing (>= 1.8)
+  mini_magick (>= 4.9)
   pry
   rubocop
   sqlite3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     active_storage_validations (0.7.0)
-      image_processing (>= 1.8)
       rails (>= 5.2.0)
 
 GEM
@@ -150,6 +149,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_storage_validations!
+  image_processing (>= 1.8)
   pry
   rubocop
   sqlite3

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ end
 ### More examples
 
 - Dimension validation with `width`, `height` and `in`.
-- Dimension detection requires `image_processing` gem.
 
 ```ruby
 class User < ApplicationRecord
@@ -130,6 +129,9 @@ Add this line to your application's Gemfile:
 
 ```ruby
 gem 'active_storage_validations'
+
+# Optional, to use :dimension validator
+gem 'image_processing'
 ```
 
 And then execute:

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Add this line to your application's Gemfile:
 gem 'active_storage_validations'
 
 # Optional, to use :dimension validator
-gem 'image_processing'
+gem 'mini_magick'
 ```
 
 And then execute:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ end
 ### More examples
 
 - Dimension validation with `width`, `height` and `in`.
+- Dimension detection requires `image_processing` gem.
 
 ```ruby
 class User < ApplicationRecord

--- a/active_storage_validations.gemspec
+++ b/active_storage_validations.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   s.add_dependency 'rails', '>= 5.2.0'
-  s.add_development_dependency 'image_processing', '>= 1.8'
+  s.add_development_dependency 'mini_magick', '>= 4.9'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'sqlite3'

--- a/active_storage_validations.gemspec
+++ b/active_storage_validations.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   s.add_dependency 'rails', '>= 5.2.0'
-  s.add_dependency 'image_processing', '>= 1.8'
+  s.add_development_dependency 'image_processing', '>= 1.8'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'sqlite3'

--- a/lib/active_storage_validations/dimension_validator.rb
+++ b/lib/active_storage_validations/dimension_validator.rb
@@ -5,7 +5,7 @@ module ActiveStorageValidations
     AVAILABLE_CHECKS = %i[width height min max].freeze
 
     def initialize(options)
-      require 'image_processing'
+      require 'mini_magick'
 
       [:width, :height].each do |length|
         if options[length] and options[length].is_a?(Hash)

--- a/lib/active_storage_validations/dimension_validator.rb
+++ b/lib/active_storage_validations/dimension_validator.rb
@@ -5,6 +5,8 @@ module ActiveStorageValidations
     AVAILABLE_CHECKS = %i[width height min max].freeze
 
     def initialize(options)
+      require 'image_processing'
+
       [:width, :height].each do |length|
         if options[length] and options[length].is_a?(Hash)
           if range = options[length][:in]

--- a/test/active_storage_validations_test.rb
+++ b/test/active_storage_validations_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require "image_processing"
 
 class ActiveStorageValidations::Test < ActiveSupport::TestCase
   test 'truth' do


### PR DESCRIPTION
Loaded explicitly in dimension validation,
since it's only required there.

My app uploads only txt files so there is no need for `image_processing`  gem in such apps.