### PR TITLE
Add support for specifying content types with symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ class User < ApplicationRecord
   validates :photos, attached: true, content_type: ['image/png', 'image/jpg', 'image/jpeg'],
                                      dimension: { width: { min: 800, max: 2400 },
                                                   height: { min: 600, max: 1800 }, message: 'is not given between dimension' }
-  validates :image, attached: true, 
+  validates :image, attached: true,
                     content_type: ['image/png', 'image/jpg'],
                     aspect_ratio: :landscape
 end
@@ -55,6 +55,18 @@ end
 ```
 
 ### More examples
+
+- Content type validation using symbols. In order to infer the correct mime type from the symbol, the types must be registered with `Mime::Type`.
+
+```ruby
+class User < ApplicationRecord
+  has_one_attached :avatar
+  has_many_attached :photos
+
+  validates :avatar, attached: true, content_type: :png # Mime[:png].to_s => 'image/png'
+  validates :photos, attached: true, content_type: [:png, :jpg, :jpeg]
+end
+```
 
 - Dimension validation with `width`, `height` and `in`.
 

--- a/lib/active_storage_validations/content_type_validator.rb
+++ b/lib/active_storage_validations/content_type_validator.rb
@@ -20,7 +20,9 @@ module ActiveStorageValidations
     end
 
     def types
-      Array.wrap(options[:with]) + Array.wrap(options[:in])
+      (Array.wrap(options[:with]) + Array.wrap(options[:in])).map do |type|
+        Mime[type] || type
+      end
     end
 
     def types_to_human_format

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -14,6 +14,6 @@ class User < ApplicationRecord
 
   validates :name, presence: true
 
-  validates :avatar, attached: true, content_type: 'image/png'
+  validates :avatar, attached: true, content_type: :png
   validates :photos, attached: true, content_type: ['image/png', 'image/jpg']
 end


### PR DESCRIPTION
Thanks for building this gem.  This PR provides a slight improvement to the API by allowing you to use symbols for the content type validation.

```ruby
class User < ApplicationRecord
  has_one_attached :avatar
  has_many_attached :photos
  
  validates :avatar, attached: true, content_type: :png
  validates :photos, attached: true, content_type: [:png, :jpg, :jpeg]
end
```

The validator code will convert the symbol to a `Mime::Type` (if it is registered), which will provide the correct content type string to compare to.  (`Mime[:png] == 'image/png' #=> true`) 