### PR TITLE
Better error messages regarding content_type

### DIFF
--- a/lib/active_storage_validations/content_type_validator.rb
+++ b/lib/active_storage_validations/content_type_validator.rb
@@ -26,7 +26,9 @@ module ActiveStorageValidations
     end
 
     def types_to_human_format
-      types.join(', ')
+      types
+        .map { |type| type.to_s.split('/').last.upcase }
+        .join(', ')
     end
 
     def content_type(file)

--- a/test/active_storage_validations_test.rb
+++ b/test/active_storage_validations_test.rb
@@ -41,6 +41,13 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     u.photos.attach(dummy_file)
     assert !u.valid?
     assert_equal u.errors.full_messages, ['Avatar has an invalid content type']
+    assert_equal u.errors.details, avatar: [
+      {
+        error: :content_type_invalid,
+        authorized_types: 'PNG',
+        content_type: 'text/plain'
+      }
+    ]
 
     u = User.new(name: 'John Smith')
     u.avatar.attach(dummy_file)


### PR DESCRIPTION
Thanks for building this gem. We were working with error messages when we realized that `authorized_types` returns the MIME type, which is not very friendly to a non-technical user:

```ruby
authorized_types: 'application/pdf, image/jpeg, image/png'
```

Hence we've done a very small change to make it friendlier:
```ruby
authorized_types: 'PDF, JPEG, PNG'
```

That can be used in the error message like this:
```yml
content_type_invalid: "is not one of the valid types: %{authorized_types}"
```