### PR TITLE
Add test matchers for validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,11 +226,11 @@ describe User do
   it { is_expected.to validate_dimensions_of(:avatar).width_between(200..500) }
   it { is_expected.to validate_dimensions_of(:avatar).height_between(100..300) }
 
-  it { is_expected.to validate_dimensions_of(:avatar).less_than(50.kilobytes) }
-  it { is_expected.to validate_dimensions_of(:avatar).less_than_or_equal_to(50.kilobytes) }
-  it { is_expected.to validate_dimensions_of(:avatar).greater_than(1.kilobyte) }
-  it { is_expected.to validate_dimensions_of(:avatar).greater_than_or_equal_to(1.kilobyte) }
-  it { is_expected.to validate_dimensions_of(:avatar).between(100..500.kilobytes) }
+  it { is_expected.to validate_size_of(:avatar).less_than(50.kilobytes) }
+  it { is_expected.to validate_size_of(:avatar).less_than_or_equal_to(50.kilobytes) }
+  it { is_expected.to validate_size_of(:avatar).greater_than(1.kilobyte) }
+  it { is_expected.to validate_size_of(:avatar).greater_than_or_equal_to(1.kilobyte) }
+  it { is_expected.to validate_size_of(:avatar).between(100..500.kilobytes) }
 end
 ```
 
@@ -267,11 +267,11 @@ class UserTest < ActiveSupport::TestCase
   should validate_dimensions_of(:avatar).width_between(200..500)
   should validate_dimensions_of(:avatar).height_between(100..300)
 
-  should validate_dimensions_of(:avatar).less_than(50.kilobytes)
-  should validate_dimensions_of(:avatar).less_than_or_equal_to(50.kilobytes)
-  should validate_dimensions_of(:avatar).greater_than(1.kilobyte)
-  should validate_dimensions_of(:avatar).greater_than_or_equal_to(1.kilobyte)
-  should validate_dimensions_of(:avatar).between(100..500.kilobytes)
+  should validate_size_of(:avatar).less_than(50.kilobytes)
+  should validate_size_of(:avatar).less_than_or_equal_to(50.kilobytes)
+  should validate_size_of(:avatar).greater_than(1.kilobyte)
+  should validate_size_of(:avatar).greater_than_or_equal_to(1.kilobyte)
+  should validate_size_of(:avatar).between(100..500.kilobytes)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ describe User do
   it { is_expected.to validate_content_type_of(:avatar).allowing('image/png', 'image/gif') }
   it { is_expected.to validate_content_type_of(:avatar).rejecting('text/plain', 'text/xml') }
 
+  it { is_expected.to validate_dimensions_of(:avatar).width(250) }
+  it { is_expected.to validate_dimensions_of(:avatar).height(200) }
   it { is_expected.to validate_dimensions_of(:avatar).width_min(200) }
   it { is_expected.to validate_dimensions_of(:avatar).width_max(500) }
   it { is_expected.to validate_dimensions_of(:avatar).height_min(100) }
@@ -256,6 +258,8 @@ class UserTest < ActiveSupport::TestCase
   should validate_content_type_of(:avatar).allowing('image/png', 'image/gif')
   should validate_content_type_of(:avatar).rejecting('text/plain', 'text/xml')
 
+  should validate_dimensions_of(:avatar).width(250)
+  should validate_dimensions_of(:avatar).height(200)
   should validate_dimensions_of(:avatar).width_min(200)
   should validate_dimensions_of(:avatar).width_max(500)
   should validate_dimensions_of(:avatar).height_min(100)

--- a/README.md
+++ b/README.md
@@ -190,7 +190,9 @@ Very simple example of validation with file attached, content type check and cus
 [![Sample](https://raw.githubusercontent.com/igorkasyanchuk/active_storage_validations/master/docs/preview.png)](https://raw.githubusercontent.com/igorkasyanchuk/active_storage_validations/master/docs/preview.png)
 
 ## Test matchers
-Provides RSpec-compatible matchers for testing the validators.
+Provides RSpec-compatible and Minitest-compatible matchers for testing the validators.
+
+### RSpec
 
 In spec_helper.rb, you'll need to require the matchers:
 
@@ -227,6 +229,45 @@ describe User do
   it { is_expected.to validate_dimensions_of(:avatar).greater_than(1.kilobyte) }
   it { is_expected.to validate_dimensions_of(:avatar).greater_than_or_equal_to(1.kilobyte) }
   it { is_expected.to validate_dimensions_of(:avatar).between(100..500.kilobytes) }
+end
+```
+
+### Minitest
+To use the following syntax, make sure you have the [shoulda-context](https://github.com/thoughtbot/shoulda-context) gem up and running. To make use of the matchers you need to require the matchers:
+
+```ruby
+require 'active_storage_validations/matchers'
+```
+
+And _extend_ the module:
+
+```bash
+class ActiveSupport::TestCase
+  extend ActiveStorageValidations::Matchers
+end
+```
+
+Example (Note that the options are chainable):
+
+```ruby
+class UserTest < ActiveSupport::TestCase
+  should validate_attached_of(:avatar)
+
+  should validate_content_type_of(:avatar).allowing('image/png', 'image/gif')
+  should validate_content_type_of(:avatar).rejecting('text/plain', 'text/xml')
+
+  should validate_dimensions_of(:avatar).width_min(200)
+  should validate_dimensions_of(:avatar).width_max(500)
+  should validate_dimensions_of(:avatar).height_min(100)
+  should validate_dimensions_of(:avatar).height_max(300)
+  should validate_dimensions_of(:avatar).width_between(200..500)
+  should validate_dimensions_of(:avatar).height_between(100..300)
+
+  should validate_dimensions_of(:avatar).less_than(50.kilobytes)
+  should validate_dimensions_of(:avatar).less_than_or_equal_to(50.kilobytes)
+  should validate_dimensions_of(:avatar).greater_than(1.kilobyte)
+  should validate_dimensions_of(:avatar).greater_than_or_equal_to(1.kilobyte)
+  should validate_dimensions_of(:avatar).between(100..500.kilobytes)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,47 @@ Very simple example of validation with file attached, content type check and cus
 
 [![Sample](https://raw.githubusercontent.com/igorkasyanchuk/active_storage_validations/master/docs/preview.png)](https://raw.githubusercontent.com/igorkasyanchuk/active_storage_validations/master/docs/preview.png)
 
+## Test matchers
+Provides RSpec-compatible matchers for testing the validators.
+
+In spec_helper.rb, you'll need to require the matchers:
+
+```ruby
+require 'active_storage_validations/matchers'
+```
+
+And _include_ the module:
+
+```ruby
+RSpec.configure do |config|
+  config.include ActiveStorageValidations::Matchers
+end
+```
+
+Example (Note that the options are chainable):
+    
+```ruby
+describe User do
+  it { is_expected.to validate_attached_of(:avatar) }
+
+  it { is_expected.to validate_content_type_of(:avatar).allowing('image/png', 'image/gif') }
+  it { is_expected.to validate_content_type_of(:avatar).rejecting('text/plain', 'text/xml') }
+
+  it { is_expected.to validate_dimensions_of(:avatar).width_min(200) }
+  it { is_expected.to validate_dimensions_of(:avatar).width_max(500) }
+  it { is_expected.to validate_dimensions_of(:avatar).height_min(100) }
+  it { is_expected.to validate_dimensions_of(:avatar).height_max(300) }
+  it { is_expected.to validate_dimensions_of(:avatar).width_between(200..500) }
+  it { is_expected.to validate_dimensions_of(:avatar).height_between(100..300) }
+
+  it { is_expected.to validate_dimensions_of(:avatar).less_than(50.kilobytes) }
+  it { is_expected.to validate_dimensions_of(:avatar).less_than_or_equal_to(50.kilobytes) }
+  it { is_expected.to validate_dimensions_of(:avatar).greater_than(1.kilobyte) }
+  it { is_expected.to validate_dimensions_of(:avatar).greater_than_or_equal_to(1.kilobyte) }
+  it { is_expected.to validate_dimensions_of(:avatar).between(100..500.kilobytes) }
+end
+```
+
 ## Todo
 
 * verify with remote storages (s3, etc)

--- a/gemfiles/rails_5_2.gemfile.lock
+++ b/gemfiles/rails_5_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_storage_validations (0.8.4)
+    active_storage_validations (0.8.6)
       rails (>= 5.2.0)
 
 GEM

--- a/gemfiles/rails_6_0.gemfile.lock
+++ b/gemfiles/rails_6_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_storage_validations (0.8.4)
+    active_storage_validations (0.8.6)
       rails (>= 5.2.0)
 
 GEM

--- a/lib/active_storage_validations/matchers.rb
+++ b/lib/active_storage_validations/matchers.rb
@@ -7,5 +7,37 @@ require 'active_storage_validations/matchers/size_validator_matcher'
 
 module ActiveStorageValidations
   module Matchers
+    # Helper to stub a method with either RSpec or Minitest (whatever is available)
+    def self.stub_method(object, method, result)
+      if defined?(Minitest::Mock)
+        object.stub(method, result) do
+          yield
+        end
+      elsif defined?(RSpec::Mocks)
+        RSpec::Mocks.allow_message(object, method) { result }
+        yield
+      else
+        raise 'Need either Minitest::Mock or RSpec::Mocks to run this validator matcher'
+      end
+    end
+
+    def self.mock_metadata(attachment, width, height)
+      if Rails::VERSION::MAJOR >= 6
+        # Mock the Metadata class for rails 6
+        mock = OpenStruct.new(metadata: { width: width, height: height })
+        stub_method(ActiveStorageValidations::Metadata, :new, mock) do
+          yield
+        end
+      else
+        # Stub the metadata analysis for rails 5
+        stub_method(attachment, :analyze, true) do
+          stub_method(attachment, :analyzed?, true) do
+            stub_method(attachment, :metadata, { width: width, height: height }) do
+              yield
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/lib/active_storage_validations/matchers.rb
+++ b/lib/active_storage_validations/matchers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'active_storage_validations/matchers/attached_validator_matcher'
+require 'active_storage_validations/matchers/content_type_validator_matcher'
+require 'active_storage_validations/matchers/dimension_validator_matcher'
+require 'active_storage_validations/matchers/size_validator_matcher'
+
+module ActiveStorageValidations
+  module Matchers
+  end
+end

--- a/lib/active_storage_validations/matchers/attached_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/attached_validator_matcher.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module ActiveStorageValidations
+  module Matchers
+    def validate_attached_of(name)
+      AttachedValidatorMatcher.new(name)
+    end
+
+    class AttachedValidatorMatcher
+      def initialize(attribute_name)
+        @attribute_name = attribute_name
+      end
+
+      def description
+        "validate #{@attribute_name} must be attached"
+      end
+
+      def matches?(subject)
+        @subject = subject.is_a?(Class) ? subject : subject.class
+
+        invalid_when_not_attached && valid_when_attached
+      end
+
+      def failure_message
+        "is expected to validate attached of #{@attribute_name}"
+      end
+
+      def failure_message_when_negated
+        "is expected to not validate attached of #{@attribute_name}"
+      end
+
+      private
+
+      def valid_when_attached
+        instance = @subject.new
+        instance.public_send(@attribute_name).attach(attachable)
+        instance.validate
+        instance.errors.details[@attribute_name].exclude?(error: :blank)
+      end
+
+      def invalid_when_not_attached
+        instance = @subject.new
+        instance.validate
+        instance.errors.details[@attribute_name].include?(error: :blank)
+      end
+
+      def attachable
+        { io: Tempfile.new('.'), filename: 'dummy.txt', content_type: 'text/plain' }
+      end
+    end
+  end
+end

--- a/lib/active_storage_validations/matchers/content_type_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/content_type_validator_matcher.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+# Big thank you to the paperclip validation matchers:
+# https://github.com/thoughtbot/paperclip/blob/v6.1.0/lib/paperclip/matchers/validate_attachment_content_type_matcher.rb
+module ActiveStorageValidations
+  module Matchers
+    def validate_content_type_of(name)
+      ContentTypeValidatorMatcher.new(name)
+    end
+
+    class ContentTypeValidatorMatcher
+      def initialize(attribute_name)
+        @attribute_name = attribute_name
+      end
+
+      def description
+        "validate the content types allowed on attachment #{@attribute_name}"
+      end
+
+      def allowing(*types)
+        @allowed_types = types.flatten
+        self
+      end
+
+      def rejecting(*types)
+        @rejected_types = types.flatten
+        self
+      end
+
+      def matches?(subject)
+        @subject = subject.is_a?(Class) ? subject.new : subject
+        allowed_types_allowed? && rejected_types_rejected?
+      end
+
+      def failure_message
+        <<~MESSAGE
+          Expected #{@attribute_name}
+            
+            Accept content types: #{allowed_types.join(", ")}
+              #{accepted_types_and_failures}
+
+            Reject content types: #{rejected_types.join(", ")}
+              #{rejected_types_and_failures}
+        MESSAGE
+      end
+
+      protected
+
+      def allowed_types
+        @allowed_types || []
+      end
+
+      def rejected_types
+        @rejected_types || (Mime::LOOKUP.keys - allowed_types)
+      end
+
+      def allowed_types_allowed?
+        @missing_allowed_types ||= allowed_types.reject { |type| type_allowed?(type) }
+        @missing_allowed_types.none?
+      end
+
+      def rejected_types_rejected?
+        @missing_rejected_types ||= rejected_types.select { |type| type_allowed?(type) }
+        @missing_rejected_types.none?
+      end
+
+      def accepted_types_and_failures
+        if @missing_allowed_types.present?
+          "#{@missing_allowed_types.join(", ")} were rejected."
+        else
+          "All were accepted successfully."
+        end
+      end
+
+      def rejected_types_and_failures
+        if @missing_rejected_types.present?
+          "#{@missing_rejected_types.join(", ")} were accepted."
+        else
+          "All were rejected successfully."
+        end
+      end
+
+      def type_allowed?(type)
+        @subject.public_send(@attribute_name).attach(attachment_for(type))
+        @subject.validate
+        @subject.errors.details[@attribute_name].all? { |error| error[:error] != :content_type_invalid }
+      end
+
+      def attachment_for(type)
+        suffix = type.to_s.split('/').last
+        { io: Tempfile.new('.'), filename: "test.#{suffix}", content_type: type }
+      end
+    end
+  end
+end

--- a/lib/active_storage_validations/matchers/dimension_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/dimension_validator_matcher.rb
@@ -47,10 +47,12 @@ module ActiveStorageValidations
 
       def width_between(range)
         @width_min, @width_max = range.first, range.last
+        self
       end
 
       def height_between(range)
         @height_min, @height_max = range.first, range.last
+        self
       end
 
       def matches?(subject)

--- a/lib/active_storage_validations/matchers/dimension_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/dimension_validator_matcher.rb
@@ -26,6 +26,11 @@ module ActiveStorageValidations
         self
       end
 
+      def width(width)
+        @width_min = @width_max = width
+        self
+      end
+
       def height_min(height)
         @height_min = height
         self
@@ -46,10 +51,15 @@ module ActiveStorageValidations
         self
       end
 
+      def height(height)
+        @height_min = @height_max = height
+        self
+      end
+
       def matches?(subject)
         @subject = subject.is_a?(Class) ? subject.new : subject
-        width_smaller_than_min? && width_larger_than_min? && width_smaller_than_max? && width_larger_than_max? &&
-          height_smaller_than_min? && height_larger_than_min? && height_smaller_than_max? && height_larger_than_max?
+        width_smaller_than_min? && width_larger_than_min? && width_smaller_than_max? && width_larger_than_max? && width_equals? &&
+          height_smaller_than_min? && height_larger_than_min? && height_smaller_than_max? && height_larger_than_max? && height_equals?
       end
 
       def failure_message
@@ -75,15 +85,19 @@ module ActiveStorageValidations
       end
 
       def width_larger_than_min?
-        @width_min.nil? || passes_validation_with_dimensions(@width_min + 1, valid_height, 'width')
+        @width_min.nil? || @width_min == @width_max || passes_validation_with_dimensions(@width_min + 1, valid_height, 'width')
       end
 
       def width_smaller_than_max?
-        @width_max.nil? || passes_validation_with_dimensions(@width_max - 1, valid_height, 'width')
+        @width_max.nil? || @width_min == @width_max || passes_validation_with_dimensions(@width_max - 1, valid_height, 'width')
       end
 
       def width_larger_than_max?
         @width_max.nil? || !passes_validation_with_dimensions(@width_max + 1, valid_height, 'width')
+      end
+
+      def width_equals?
+        @width_min.nil? || @width_min != @width_max || passes_validation_with_dimensions(@width_min, valid_height, 'width')
       end
 
       def height_smaller_than_min?
@@ -91,15 +105,19 @@ module ActiveStorageValidations
       end
 
       def height_larger_than_min?
-        @height_min.nil? || passes_validation_with_dimensions(valid_width, @height_min + 1, 'height')
+        @height_min.nil? || @height_min == @height_max || passes_validation_with_dimensions(valid_width, @height_min + 1, 'height')
       end
 
       def height_smaller_than_max?
-        @height_max.nil? || passes_validation_with_dimensions(valid_width, @height_max - 1, 'height')
+        @height_max.nil? || @height_min == @height_max || passes_validation_with_dimensions(valid_width, @height_max - 1, 'height')
       end
 
       def height_larger_than_max?
         @height_max.nil? || !passes_validation_with_dimensions(valid_width, @height_max + 1, 'height')
+      end
+
+      def height_equals?
+        @height_min.nil? || @height_min != @height_max || passes_validation_with_dimensions(valid_width, @height_min, 'height')
       end
 
       def passes_validation_with_dimensions(width, height, check)

--- a/lib/active_storage_validations/matchers/dimension_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/dimension_validator_matcher.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+begin
+  require 'minitest/mock'
+rescue LoadError
+end
+begin
+  require 'rspec/mocks/standalone'
+rescue LoadError
+end
+
+module ActiveStorageValidations
+  module Matchers
+    def validate_dimensions_of(name)
+      DimensionValidatorMatcher.new(name)
+    end
+
+    class DimensionValidatorMatcher
+      def initialize(attribute_name)
+        @attribute_name = attribute_name
+        @width_min = @width_max = @height_min = @height_max = nil
+      end
+
+      def description
+        "validate image dimensions of #{@attribute_name}"
+      end
+
+      def width_min(width)
+        @width_min = width
+        self
+      end
+
+      def width_max(width)
+        @width_max = width
+        self
+      end
+
+      def height_min(height)
+        @height_min = height
+        self
+      end
+
+      def height_max(height)
+        @height_max = height
+        self
+      end
+
+      def width_between(range)
+        @width_min, @width_max = range.first, range.last
+      end
+
+      def height_between(range)
+        @height_min, @height_max = range.first, range.last
+      end
+
+      def matches?(subject)
+        @subject = subject.is_a?(Class) ? subject.new : subject
+        width_smaller_than_min? && width_larger_than_min? && width_smaller_than_max? && width_larger_than_max? &&
+          height_smaller_than_min? && height_larger_than_min? && height_smaller_than_max? && height_larger_than_max?
+      end
+
+      def failure_message
+        <<~MESSAGE
+          is expected to validate dimensions of #{@attribute_name}
+            width between #{@width_min} and #{@width_max}
+            height between #{@height_min} and #{@height_max}
+        MESSAGE
+      end
+
+      protected
+
+      def valid_width
+        ((@width_min || 0) + (@width_max || 2000)) / 2
+      end
+
+      def valid_height
+        ((@height_min || 0) + (@height_max || 2000)) / 2
+      end
+
+      def width_smaller_than_min?
+        @width_min.nil? || !passes_validation_with_dimensions(@width_min - 1, valid_height, 'width')
+      end
+
+      def width_larger_than_min?
+        @width_min.nil? || passes_validation_with_dimensions(@width_min + 1, valid_height, 'width')
+      end
+
+      def width_smaller_than_max?
+        @width_max.nil? || passes_validation_with_dimensions(@width_max - 1, valid_height, 'width')
+      end
+
+      def width_larger_than_max?
+        @width_max.nil? || !passes_validation_with_dimensions(@width_max + 1, valid_height, 'width')
+      end
+
+      def height_smaller_than_min?
+        @height_min.nil? || !passes_validation_with_dimensions(valid_width, @height_min - 1, 'height')
+      end
+
+      def height_larger_than_min?
+        @height_min.nil? || passes_validation_with_dimensions(valid_width, @height_min + 1, 'height')
+      end
+
+      def height_smaller_than_max?
+        @height_max.nil? || passes_validation_with_dimensions(valid_width, @height_max - 1, 'height')
+      end
+
+      def height_larger_than_max?
+        @height_max.nil? || !passes_validation_with_dimensions(valid_width, @height_max + 1, 'height')
+      end
+
+      def passes_validation_with_dimensions(width, height, check)
+        @subject.public_send(@attribute_name).attach attachment_for(width, height)
+
+        mock_metadata(width, height) do
+          @subject.validate
+          @subject.errors.details[@attribute_name].all? { |error| error[:error].to_s.exclude?("dimension_#{check}") }
+        end
+      end
+
+      def mock_metadata(width, height)
+        # Stub the metadata analysis for rails 5
+        if Rails::VERSION::MAJOR == 5
+          attachment = @subject.public_send(@attribute_name)
+          override_method(attachment, :analyze) { true }
+          override_method(attachment, :analyzed?) { true }
+          override_method(attachment, :metadata) { { width: width, height: height } }
+        end
+
+        # Mock the Metadata class for rails 6
+        mock = OpenStruct.new(metadata: { width: width, height: height })
+        if defined?(Minitest::Mock)
+          ActiveStorageValidations::Metadata.stub(:new, mock) do
+            yield
+          end
+        elsif defined?(RSpec::Mocks)
+          ActiveStorageValidations::Metadata.stub(:new) { mock }
+          yield
+        else
+          raise 'Need either Minitest::Mock or RSpec::Mocks to run this validator matcher'
+        end
+      end
+
+      def override_method(object, method, &replacement)
+        (class << object; self; end).class_eval do
+          undef_method(method) if method_defined?(method)
+          define_method(method, &replacement)
+        end
+      end
+
+      def attachment_for(width, height)
+        { io: Tempfile.new('Hello world!'), filename: 'test.png', content_type: 'image/png' }
+      end
+    end
+  end
+end

--- a/lib/active_storage_validations/matchers/size_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/size_validator_matcher.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# Big thank you to the paperclip validation matchers:
+# https://github.com/thoughtbot/paperclip/blob/v6.1.0/lib/paperclip/matchers/validate_attachment_size_matcher.rb
+module ActiveStorageValidations
+  module Matchers
+    def validate_size_of(name)
+      SizeValidatorMatcher.new(name)
+    end
+
+    class SizeValidatorMatcher
+      def initialize(attribute_name)
+        @attribute_name = attribute_name
+        @low = @high = nil
+      end
+
+      def description
+        "validate file size of #{@attribute_name}"
+      end
+
+      def less_than(size)
+        @high = size - 1.byte
+        self
+      end
+
+      def less_than_or_equal_to(size)
+        @high = size
+        self
+      end
+
+      def greater_than(size)
+        @low = size + 1.byte
+        self
+      end
+
+      def greater_than_or_equal_to(size)
+        @low = size
+        self
+      end
+
+      def between(range)
+        @low, @high = range.first, range.last
+        self
+      end
+
+      def matches?(subject)
+        @subject = subject.is_a?(Class) ? subject.new : subject
+        lower_than_low? && higher_than_low? && lower_than_high? && higher_than_high?
+      end
+
+      def failure_message
+        "is expected to validate file size of #{@attribute_name} to be between #{@low} and #{@high} bytes"
+      end
+
+      def failure_message_when_negated
+        "is expected to not validate file size of #{@attribute_name} to be between #{@low} and #{@high} bytes"
+      end
+
+      protected
+
+      def lower_than_low?
+        @low.nil? || !passes_validation_with_size(@low - 1)
+      end
+
+      def higher_than_low?
+        @low.nil? || passes_validation_with_size(@low + 1)
+      end
+
+      def lower_than_high?
+        @high.nil? || @high == Float::INFINITY || passes_validation_with_size(@high - 1)
+      end
+
+      def higher_than_high?
+        @high.nil? || @high == Float::INFINITY || !passes_validation_with_size(@high + 1)
+      end
+
+      def passes_validation_with_size(new_size)
+        @subject.public_send(@attribute_name).attach attachment_for(new_size)
+        @subject.validate
+        @subject.errors.details[@attribute_name].all? { |error| error[:error] != :file_size_out_of_range }
+      end
+
+      def override_method(object, method, &replacement)
+        (class << object; self; end).class_eval do
+          undef_method(method) if method_defined?(method)
+          define_method(method, &replacement)
+        end
+      end
+
+      def attachment_for(size)
+        io = Tempfile.new('Hello world!')
+        override_method(io, :size) { size }
+        { io: io, filename: 'test.png', content_type: 'image/pg' }
+      end
+    end
+  end
+end

--- a/test/active_storage_validations_test.rb
+++ b/test/active_storage_validations_test.rb
@@ -113,7 +113,7 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     assert !la.valid?
 
     assert_equal 6, la.files.count
-    
+
     if Rails.version < "6.0.0"
       assert_equal 6, la.files_blobs.count
     else
@@ -141,7 +141,7 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     assert_equal 3, la.files.count
     assert la.save
     la.reload
-    
+
     assert_equal 3, la.files_blobs.count
     la.files.first.purge
 
@@ -157,7 +157,7 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     assert !la.valid?
     assert_equal 5, la.files.count
     assert !la.save
-  end  
+  end
 
   test 'dimensions and is image' do
     e = OnlyImage.new

--- a/test/matchers/attached_validator_matcher_test.rb
+++ b/test/matchers/attached_validator_matcher_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'active_storage_validations/matchers/attached_validator_matcher'
+
+class ActiveStorageValidations::Matchers::AttachedValidatorMatcher::Test < ActiveSupport::TestCase
+  test 'positive match when providing class' do
+    matcher = ActiveStorageValidations::Matchers::AttachedValidatorMatcher.new(:avatar)
+    assert matcher.matches?(User)
+  end
+
+  test 'negative match when providing class' do
+    matcher = ActiveStorageValidations::Matchers::AttachedValidatorMatcher.new(:image_regex)
+    refute matcher.matches?(User)
+  end
+
+  test 'unkown attached when providing class' do
+    matcher = ActiveStorageValidations::Matchers::AttachedValidatorMatcher.new(:non_existing)
+    refute matcher.matches?(User)
+  end
+
+  test 'positive match when providing instance' do
+    matcher = ActiveStorageValidations::Matchers::AttachedValidatorMatcher.new(:avatar)
+    assert matcher.matches?(User.new)
+  end
+
+  test 'negative match when providing instance' do
+    matcher = ActiveStorageValidations::Matchers::AttachedValidatorMatcher.new(:image_regex)
+    refute matcher.matches?(User.new)
+  end
+
+  test 'unkown attached when providing instance' do
+    matcher = ActiveStorageValidations::Matchers::AttachedValidatorMatcher.new(:non_existing)
+    refute matcher.matches?(User.new)
+  end
+end

--- a/test/matchers/attached_validator_matcher_test.rb
+++ b/test/matchers/attached_validator_matcher_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'active_storage_validations/matchers/attached_validator_matcher'
+require 'active_storage_validations/matchers'
 
 class ActiveStorageValidations::Matchers::AttachedValidatorMatcher::Test < ActiveSupport::TestCase
   test 'positive match when providing class' do

--- a/test/matchers/content_type_validator_matcher_test.rb
+++ b/test/matchers/content_type_validator_matcher_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'active_storage_validations/matchers/content_type_validator_matcher'
+
+class ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher::Test < ActiveSupport::TestCase
+  test 'positive match when providing class' do
+    matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:avatar)
+    matcher.allowing('image/png')
+    matcher.rejecting('application/pdf')
+    assert matcher.matches?(User)
+  end
+
+  test 'negative match when providing class' do
+    matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:avatar)
+    matcher.allowing('image/jpg')
+    refute matcher.matches?(User)
+  end
+
+  test 'positive match when providing instance' do
+    matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:avatar)
+    matcher.allowing('image/png')
+    matcher.rejecting('application/pdf')
+    assert matcher.matches?(User.new)
+  end
+
+  test 'negative match when providing instance' do
+    matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:avatar)
+    matcher.allowing('image/jpg')
+    refute matcher.matches?(User.new)
+  end
+end

--- a/test/matchers/content_type_validator_matcher_test.rb
+++ b/test/matchers/content_type_validator_matcher_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'active_storage_validations/matchers/content_type_validator_matcher'
+require 'active_storage_validations/matchers'
 
 class ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher::Test < ActiveSupport::TestCase
   test 'positive match when providing class' do

--- a/test/matchers/dimension_validator_matcher_test.rb
+++ b/test/matchers/dimension_validator_matcher_test.rb
@@ -40,6 +40,27 @@ class ActiveStorageValidations::Matchers::DimensionValidatorMatcher::Test < Acti
     refute matcher.matches?(Project)
   end
 
+  test 'width positive exact match' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_exact)
+    matcher.width 150
+    matcher.height 150 # Make sure the validation on height is ok
+    assert matcher.matches?(Project)
+  end
+
+  test 'width bigger than exact match' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_exact)
+    matcher.width 999
+    matcher.height 150 # Make sure the validation on height is ok
+    refute matcher.matches?(Project)
+  end
+
+  test 'width smaller than exact match' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_exact)
+    matcher.width 50
+    matcher.height 150 # Make sure the validation on height is ok
+    refute matcher.matches?(Project)
+  end
+
   test 'height positive match on lower' do
     matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
     matcher.height_min 600
@@ -73,6 +94,27 @@ class ActiveStorageValidations::Matchers::DimensionValidatorMatcher::Test < Acti
   test 'height higher than higher' do
     matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
     matcher.height_max 1000
+    refute matcher.matches?(Project)
+  end
+
+  test 'height positive exact match' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_exact)
+    matcher.width 150 # Make sure the validation on width is ok
+    matcher.height 150
+    assert matcher.matches?(Project)
+  end
+
+  test 'height bigger than exact match' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_exact)
+    matcher.width 150 # Make sure the validation on width is ok
+    matcher.height 999
+    refute matcher.matches?(Project)
+  end
+
+  test 'smaller smaller than exact match' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_exact)
+    matcher.width 150 # Make sure the validation on width is ok
+    matcher.height 50
     refute matcher.matches?(Project)
   end
 end

--- a/test/matchers/dimension_validator_matcher_test.rb
+++ b/test/matchers/dimension_validator_matcher_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'active_storage_validations/matchers/dimension_validator_matcher'
+
+class ActiveStorageValidations::Matchers::DimensionValidatorMatcher::Test < ActiveSupport::TestCase
+  test 'width positive match on lower' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
+    matcher.width_min 800
+    assert matcher.matches?(Project)
+  end
+
+  test 'width less than lower' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
+    matcher.width_min 700
+    refute matcher.matches?(Project)
+  end
+
+  test 'width higher than lower' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
+    matcher.width_min 900
+    refute matcher.matches?(Project)
+  end
+
+  test 'width positive match on higher' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
+    matcher.width_max 1200
+    assert matcher.matches?(Project)
+  end
+
+  test 'width less than higher' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
+    matcher.width_max 1100
+    refute matcher.matches?(Project)
+  end
+
+  test 'width higher than higher' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
+    matcher.width_max 1300
+    refute matcher.matches?(Project)
+  end
+
+  test 'height positive match on lower' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
+    matcher.height_min 600
+    assert matcher.matches?(Project)
+  end
+
+  test 'height less than lower' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
+    matcher.height_min 500
+    refute matcher.matches?(Project)
+  end
+
+  test 'height higher than lower' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
+    matcher.height_min 700
+    refute matcher.matches?(Project)
+  end
+
+  test 'height positive match on higher' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
+    matcher.height_max 900
+    assert matcher.matches?(Project)
+  end
+
+  test 'height less than higher' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
+    matcher.height_max 800
+    refute matcher.matches?(Project)
+  end
+
+  test 'height higher than higher' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
+    matcher.height_max 1000
+    refute matcher.matches?(Project)
+  end
+end

--- a/test/matchers/dimension_validator_matcher_test.rb
+++ b/test/matchers/dimension_validator_matcher_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'active_storage_validations/matchers/dimension_validator_matcher'
+require 'active_storage_validations/matchers'
 
 class ActiveStorageValidations::Matchers::DimensionValidatorMatcher::Test < ActiveSupport::TestCase
   test 'width positive match on lower' do

--- a/test/matchers/size_validator_matcher_test.rb
+++ b/test/matchers/size_validator_matcher_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'active_storage_validations/matchers/size_validator_matcher'
+require 'active_storage_validations/matchers'
 
 class ActiveStorageValidations::Matchers::SizeValidatorMatcher::Test < ActiveSupport::TestCase
   test 'positive match greater than' do

--- a/test/matchers/size_validator_matcher_test.rb
+++ b/test/matchers/size_validator_matcher_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'active_storage_validations/matchers/size_validator_matcher'
+
+class ActiveStorageValidations::Matchers::SizeValidatorMatcher::Test < ActiveSupport::TestCase
+  test 'positive match greater than' do
+    matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:preview)
+    matcher.greater_than 1.kilobyte
+    assert matcher.matches?(Project)
+  end
+
+  test 'higher than greater then' do
+    matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:preview)
+    matcher.greater_than 2.kilobyte
+    refute matcher.matches?(Project)
+  end
+
+  test 'lower than greater then' do
+    matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:preview)
+    matcher.greater_than 0.5.kilobyte
+    refute matcher.matches?(Project)
+  end
+
+  test 'positive match between' do
+    matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:attachment)
+    matcher.between 0..500.kilobytes
+    assert matcher.matches?(Project)
+  end
+
+  test 'low too high match between' do
+    matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:attachment)
+    matcher.between 100..500.kilobytes
+    refute matcher.matches?(Project)
+  end
+
+  test 'high too high match between' do
+    matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:attachment)
+    matcher.between 0..600.kilobytes
+    refute matcher.matches?(Project)
+  end
+
+  test 'high too low match between' do
+    matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:attachment)
+    matcher.between 0..400.kilobytes
+    refute matcher.matches?(Project)
+  end
+
+  test 'positive match less than' do
+    matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:small_file)
+    matcher.less_than 1.kilobyte
+    assert matcher.matches?(Project)
+  end
+
+  test 'higher then less than' do
+    matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:small_file)
+    matcher.less_than 2.kilobyte
+    refute matcher.matches?(Project)
+  end
+
+  test 'lower then less than' do
+    matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:small_file)
+    matcher.less_than 0.5.kilobyte
+    refute matcher.matches?(Project)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ ENV['RAILS_ENV'] = 'test'
 require_relative '../test/dummy/config/environment'
 ActiveRecord::Migrator.migrations_paths = [File.expand_path('../test/dummy/db/migrate', __dir__)]
 require 'rails/test_help'
+require 'minitest/mock'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.


### PR DESCRIPTION
I worked on a first version of the test matchers as requested in https://github.com/igorkasyanchuk/active_storage_validations/issues/48. For now I've only implemented:
- `AttachedValidatorMatcher`
- `ContentTypeValidatorMatcher`
- `DimensionValidatorMatcher`
- `SizeValidatorMatcher`

and they should also be extended more to test all options of the validators (like message and validation context). But I hope it is a starting point and that we can add a complete set of matchers for all validators. 