### PR TITLE
Rails 5.2 attachement purge on content type invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ end
 To run tests in root folder of gem:
 
 * `BUNDLE_GEMFILE=gemfiles/rails_5_2.gemfile bundle exec rake test` to run for Rails 5.2
-* `BUNDLE_GEMFILE=gemfiles/rails_6.0.gemfile bundle exec rake test` to run for Rails 6.0
+* `BUNDLE_GEMFILE=gemfiles/rails_6_0.gemfile bundle exec rake test` to run for Rails 6.0
 
 To play with app `cd test/dummy` and `rails s -b 0.0.0.0` (before `rails db:migrate`).
 

--- a/lib/active_storage_validations/content_type_validator.rb
+++ b/lib/active_storage_validations/content_type_validator.rb
@@ -2,7 +2,7 @@
 
 module ActiveStorageValidations
   class ContentTypeValidator < ActiveModel::EachValidator # :nodoc:
-    def validate_each(record, attribute, _value)
+    def validate_each(record, attribute, value)
       return true if !record.send(attribute).attached? || types.empty?
 
       files = Array.wrap(record.send(attribute))
@@ -15,6 +15,8 @@ module ActiveStorageValidations
 
         errors_options[:content_type] = content_type(file)
         record.errors.add(attribute, :content_type_invalid, errors_options)
+
+        value.purge if "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}" == '5.2'
         break
       end
     end


### PR DESCRIPTION
Hi,
Following the #55 issue, here are 2 commits to get started:
* The first one adds a failing test to check that an attached file with an invalid content type gets purged in rails 5.2
* The second one is a lead that I used in my project (I had to use `.purge` in a controller), but as mentioned in the issue, it apparently messes up the validation callbacks. In this case, this messes up another seemingly unrelated test. You can use it to see where it fails, but another solution seems to be necessary. So this 2nd commit is just an example.

I'm still a beginner, so I hope this isn't too 'dirty'. Also, I would love to know your solution to this problem :)