### PR TITLE
Ensure to detach attachment before validating attached

### DIFF
--- a/gemfiles/rails_5_2.gemfile.lock
+++ b/gemfiles/rails_5_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_storage_validations (0.8.9)
+    active_storage_validations (0.9.0)
       rails (>= 5.2.0)
 
 GEM

--- a/gemfiles/rails_6_0.gemfile.lock
+++ b/gemfiles/rails_6_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_storage_validations (0.8.9)
+    active_storage_validations (0.9.0)
       rails (>= 5.2.0)
 
 GEM

--- a/lib/active_storage_validations/matchers/content_type_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/content_type_validator_matcher.rb
@@ -29,7 +29,7 @@ module ActiveStorageValidations
 
       def matches?(subject)
         @subject = subject.is_a?(Class) ? subject.new : subject
-        allowed_types_allowed? && rejected_types_rejected?
+        responds_to_methods && allowed_types_allowed? && rejected_types_rejected?
       end
 
       def failure_message
@@ -45,6 +45,12 @@ module ActiveStorageValidations
       end
 
       protected
+
+      def responds_to_methods
+        @subject.respond_to?(@attribute_name) &&
+          @subject.public_send(@attribute_name).respond_to?(:attach) &&
+          @subject.public_send(@attribute_name).respond_to?(:detach)
+      end
 
       def allowed_types
         @allowed_types || []

--- a/lib/active_storage_validations/matchers/dimension_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/dimension_validator_matcher.rb
@@ -58,7 +58,8 @@ module ActiveStorageValidations
 
       def matches?(subject)
         @subject = subject.is_a?(Class) ? subject.new : subject
-        width_smaller_than_min? && width_larger_than_min? && width_smaller_than_max? && width_larger_than_max? && width_equals? &&
+        responds_to_methods &&
+          width_smaller_than_min? && width_larger_than_min? && width_smaller_than_max? && width_larger_than_max? && width_equals? &&
           height_smaller_than_min? && height_larger_than_min? && height_smaller_than_max? && height_larger_than_max? && height_equals?
       end
 
@@ -71,6 +72,12 @@ module ActiveStorageValidations
       end
 
       protected
+
+      def responds_to_methods
+        @subject.respond_to?(@attribute_name) &&
+          @subject.public_send(@attribute_name).respond_to?(:attach) &&
+          @subject.public_send(@attribute_name).respond_to?(:detach)
+      end
 
       def valid_width
         ((@width_min || 0) + (@width_max || 2000)) / 2

--- a/lib/active_storage_validations/matchers/size_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/size_validator_matcher.rb
@@ -45,7 +45,7 @@ module ActiveStorageValidations
 
       def matches?(subject)
         @subject = subject.is_a?(Class) ? subject.new : subject
-        lower_than_low? && higher_than_low? && lower_than_high? && higher_than_high?
+        responds_to_methods && lower_than_low? && higher_than_low? && lower_than_high? && higher_than_high?
       end
 
       def failure_message
@@ -57,6 +57,12 @@ module ActiveStorageValidations
       end
 
       protected
+
+      def responds_to_methods
+        @subject.respond_to?(@attribute_name) &&
+          @subject.public_send(@attribute_name).respond_to?(:attach) &&
+          @subject.public_send(@attribute_name).respond_to?(:detach)
+      end
 
       def lower_than_low?
         @low.nil? || !passes_validation_with_size(@low - 1)

--- a/test/matchers/attached_validator_matcher_test.rb
+++ b/test/matchers/attached_validator_matcher_test.rb
@@ -43,4 +43,11 @@ class ActiveStorageValidations::Matchers::AttachedValidatorMatcher::Test < Activ
     matcher = ActiveStorageValidations::Matchers::AttachedValidatorMatcher.new(:conditional_image)
     refute matcher.matches?(User.new)
   end
+
+  test 'positive match when providing instance with attachment' do
+    matcher = ActiveStorageValidations::Matchers::AttachedValidatorMatcher.new(:avatar)
+    user = User.new
+    user.avatar.attach(io: Tempfile.new('.'), filename: 'image.png', content_type: 'image/png')
+    assert matcher.matches?(user)
+  end
 end

--- a/test/matchers/content_type_validator_matcher_test.rb
+++ b/test/matchers/content_type_validator_matcher_test.rb
@@ -17,6 +17,12 @@ class ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher::Test < Ac
     refute matcher.matches?(User)
   end
 
+  test 'unkown attached when providing class' do
+    matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:non_existing)
+    matcher.allowing('image/png')
+    refute matcher.matches?(User)
+  end
+
   test 'positive match when providing instance' do
     matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:avatar)
     matcher.allowing('image/png')
@@ -27,6 +33,12 @@ class ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher::Test < Ac
   test 'negative match when providing instance' do
     matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:avatar)
     matcher.allowing('image/jpg')
+    refute matcher.matches?(User.new)
+  end
+
+  test 'unkown attached when providing instance' do
+    matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:non_existing)
+    matcher.allowing('image/png')
     refute matcher.matches?(User.new)
   end
 end

--- a/test/matchers/dimension_validator_matcher_test.rb
+++ b/test/matchers/dimension_validator_matcher_test.rb
@@ -117,4 +117,22 @@ class ActiveStorageValidations::Matchers::DimensionValidatorMatcher::Test < Acti
     matcher.height 50
     refute matcher.matches?(Project)
   end
+
+  test 'works when providing an instance' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_range)
+    matcher.width_min 800
+    assert matcher.matches?(Project.new)
+  end
+
+  test 'unkown attached when providing class' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:non_existing)
+    matcher.width_min 800
+    refute matcher.matches?(Project)
+  end
+
+  test 'unkown attached when providing instance' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:non_existing)
+    matcher.width_min 800
+    refute matcher.matches?(Project.new)
+  end
 end

--- a/test/matchers/size_validator_matcher_test.rb
+++ b/test/matchers/size_validator_matcher_test.rb
@@ -63,4 +63,22 @@ class ActiveStorageValidations::Matchers::SizeValidatorMatcher::Test < ActiveSup
     matcher.less_than 0.5.kilobyte
     refute matcher.matches?(Project)
   end
+
+  test 'works when providing an instance' do
+    matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:preview)
+    matcher.greater_than 1.kilobyte
+    assert matcher.matches?(Project.new)
+  end
+
+  test 'unkown attached when providing class' do
+    matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:non_existing)
+    matcher.greater_than 1.kilobyte
+    refute matcher.matches?(Project)
+  end
+
+  test 'unkown attached when providing instance' do
+    matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:non_existing)
+    matcher.greater_than 1.kilobyte
+    refute matcher.matches?(Project.new)
+  end
 end


### PR DESCRIPTION
It's a bit related to #78. In the case where you provide an instance which already has an attachment to the attached validator, you get a failure. So this example will fail while the attached validation is actually in place:

```ruby
subject { build :user, :with_avatar } # You get the point of this being factory bot that builds a user with an avatar attached
it { is_expected.to validate_attached_of :avatar } # This then fails
```

This PR fixes that case. And while I was on it I've also added additional checks to the matchers (I should have probably made a separate PR for this 🙈 ).

So hope you get the idea and let me know if there are any questions!
