### PR TITLE
Update find_signed to find_signed! for Rails 6.1

### DIFF
--- a/lib/active_storage_validations/metadata.rb
+++ b/lib/active_storage_validations/metadata.rb
@@ -21,7 +21,17 @@ module ActiveStorageValidations
     def read_image
       is_string = file.is_a?(String)
       if is_string || file.is_a?(ActiveStorage::Blob)
-        blob = is_string ? ActiveStorage::Blob.find_signed(file) : file
+        if is_string
+          # If Rails 5.2 or 6.0, use `find_signed`
+          if Rails::VERSION::MAJOR < 6 || (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR == 0)
+            blob = ActiveStorage::Blob.find_signed(file)
+          # If Rails 6.1 or higher, use `find_signed!`
+          elsif Rails::VERSION::MAJOR > 6 || (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR >= 1)
+            blob = ActiveStorage::Blob.find_signed!(file)
+          end
+        else
+          blob = file
+        end
 
         tempfile = Tempfile.new(["ActiveStorage-#{blob.id}-", blob.filename.extension_with_delimiter])
         tempfile.binmode


### PR DESCRIPTION
`find_signed` no longer works in Rails 6.1, but `find_signed!` does.

So we add a version check and use a different method depending on the Rails version.

I tested this in my application [vglist](https://github.com/connorshea/vglist) and it fixes the error, although I'm not sure how it should have an automated test written for it.

Fixes #93.

I'm sure there's a better way to determine the Rails version here, but I couldn't think of anything else that would work for, e.g. Rails 6.2, Rails 7, etc.