### PR TITLE
Fix build

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,4 @@
-en:
+es:
   errors:
     messages:
       content_type_invalid: "tiene un tipo de contenido inválido"

--- a/gemfiles/rails_5_2.gemfile.lock
+++ b/gemfiles/rails_5_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_storage_validations (0.9.0)
+    active_storage_validations (0.9.1)
       rails (>= 5.2.0)
 
 GEM

--- a/test/matchers/attached_validator_matcher_test.rb
+++ b/test/matchers/attached_validator_matcher_test.rb
@@ -50,4 +50,14 @@ class ActiveStorageValidations::Matchers::AttachedValidatorMatcher::Test < Activ
     user.avatar.attach(io: Tempfile.new('.'), filename: 'image.png', content_type: 'image/png')
     assert matcher.matches?(user)
   end
+
+  test 'positive match when providing persisted instance with attachment' do
+    matcher = ActiveStorageValidations::Matchers::AttachedValidatorMatcher.new(:avatar)
+    user = User.create!(
+      name: 'Pietje',
+      avatar: { io: Tempfile.new('.'), filename: 'image.png', content_type: 'image/png' },
+      photos: [{ io: Tempfile.new('.'), filename: 'image.png', content_type: 'image/png' }]
+    )
+    assert matcher.matches?(user)
+  end
 end


### PR DESCRIPTION
As discussed in https://github.com/igorkasyanchuk/active_storage_validations/pull/81, I would fix the current build. 

The solution consisted of two steps:
- The addition of the Spanish translations where added with an incorrect key.
- My PR with the attached validator didn't properly unset the relation for unpersisted records.

I think it's a good idea to properly test the matchers on a real world codebase before putting out the release. I'll try running it against one of our apps.