### PR TITLE
Allow regex in content_type arrays

### DIFF
--- a/lib/active_storage_validations/content_type_validator.rb
+++ b/lib/active_storage_validations/content_type_validator.rb
@@ -36,10 +36,9 @@ module ActiveStorageValidations
     end
 
     def is_valid?(file)
-      if options[:with].is_a?(Regexp)
-        options[:with].match?(content_type(file).to_s)
-      else
-        content_type(file).in?(types)
+      file_type = content_type(file)
+      types.any? do |type|
+        type == file_type || (type.is_a?(Regexp) && type.match?(file_type.to_s))
       end
     end
   end

--- a/test/active_storage_validations_test.rb
+++ b/test/active_storage_validations_test.rb
@@ -51,6 +51,12 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
 
     u = User.new(name: 'John Smith')
     u.avatar.attach(dummy_file)
+    u.image_regex.attach(dummy_file)
+    u.photos.attach(pdf_file) # Should be handled by regex match.
+    assert u.valid?
+
+    u = User.new(name: 'John Smith')
+    u.avatar.attach(dummy_file)
     u.image_regex.attach(bad_dummy_file)
     u.photos.attach(dummy_file)
     assert !u.valid?

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   validates :name, presence: true
 
   validates :avatar, attached: true, content_type: :png
-  validates :photos, attached: true, content_type: ['image/png', 'image/jpg']
+  validates :photos, attached: true, content_type: ['image/png', 'image/jpg', /\A.*\/pdf\z/]
   validates :image_regex, content_type: /\Aimage\/.*\z/
   validates :conditional_image, attached: true, if: -> { name == 'Foo' }
 end


### PR DESCRIPTION
As of https://github.com/igorkasyanchuk/active_storage_validations/pull/38, regex was accepted as an individual content_type argument, now this allows regex in content_type arrays also.