### PR TITLE
Fix wrong spanish translation

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -17,6 +17,6 @@ es:
       dimension_height_equal_to: "la altura debe ser igual a %{length} pixel"
       aspect_ratio_not_square: "debe ser una imagen cuadrada"
       aspect_ratio_not_portrait: "debe ser una imagen de retrato"
-      aspect_ratio_not_landscape: "debe ser una imagen de paisaje"
+      aspect_ratio_not_landscape: "debe ser una imagen apaisada"
       aspect_ratio_is_not: "debe tener una relación de aspecto de %{aspect_ratio}"
       aspect_ratio_unknown: "tiene una relación de aspecto desconocida"


### PR DESCRIPTION
Previous text means: `The image must be a landscape`

The new text means the image must be more wide than hight.