### PR TITLE
Add with_message for dimension_validator_matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ describe User do
 
   it { is_expected.to validate_dimensions_of(:avatar).width(250) }
   it { is_expected.to validate_dimensions_of(:avatar).height(200) }
+  it { is_expected.to validate_dimensions_of(:avatar).width(250).height(200).with_message('Invalid dimensions.') }
   it { is_expected.to validate_dimensions_of(:avatar).width_min(200) }
   it { is_expected.to validate_dimensions_of(:avatar).width_max(500) }
   it { is_expected.to validate_dimensions_of(:avatar).height_min(100) }
@@ -261,6 +262,7 @@ class UserTest < ActiveSupport::TestCase
 
   should validate_dimensions_of(:avatar).width(250)
   should validate_dimensions_of(:avatar).height(200)
+  should validate_dimensions_of(:avatar).width(250).height(200).with_message('Invalid dimensions.')
   should validate_dimensions_of(:avatar).width_min(200)
   should validate_dimensions_of(:avatar).width_max(500)
   should validate_dimensions_of(:avatar).height_min(100)

--- a/lib/active_storage_validations/matchers/dimension_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/dimension_validator_matcher.rb
@@ -10,6 +10,7 @@ module ActiveStorageValidations
       def initialize(attribute_name)
         @attribute_name = attribute_name
         @width_min = @width_max = @height_min = @height_max = nil
+        @custom_message = nil
       end
 
       def description
@@ -23,6 +24,11 @@ module ActiveStorageValidations
 
       def width_max(width)
         @width_max = width
+        self
+      end
+
+      def with_message(message)
+        @custom_message = message
         self
       end
 
@@ -133,7 +139,8 @@ module ActiveStorageValidations
         attachment = @subject.public_send(@attribute_name)
         Matchers.mock_metadata(attachment, width, height) do
           @subject.validate
-          @subject.errors.details[@attribute_name].all? { |error| error[:error].to_s.exclude?("dimension_#{check}") }
+          exclude_error_message = @custom_message || "dimension_#{check}"
+          @subject.errors.details[@attribute_name].all? { |error| error[:error].to_s.exclude?(exclude_error_message) }
         end
       end
 

--- a/test/dummy/app/models/project.rb
+++ b/test/dummy/app/models/project.rb
@@ -15,6 +15,7 @@ class Project < ApplicationRecord
   has_one_attached :attachment
   has_one_attached :small_file
   has_one_attached :dimension_exact
+  has_one_attached :dimension_exact_with_message
   has_one_attached :dimension_range
   has_one_attached :dimension_min
   has_one_attached :dimension_max
@@ -28,9 +29,10 @@ class Project < ApplicationRecord
   validates :small_file, attached: true, size: { less_than: 1.kilobytes }
   validates :documents, limit: { min: 1, max: 3 }
 
-  validates :dimension_exact,  dimension: { width: 150, height: 150 }
-  validates :dimension_range,  dimension: { width: { in: 800..1200 }, height: { in: 600..900 } }
-  validates :dimension_min,    dimension: { min: 800..600 }
-  validates :dimension_max,    dimension: { max: 1200..900 }
-  validates :dimension_images, dimension: { width: { min: 800, max: 1200 }, height: { min: 600, max: 900 } }
+  validates :dimension_exact,               dimension: { width: 150, height: 150 }
+  validates :dimension_exact_with_message,  dimension: { width: 150, height: 150, message: 'Invalid dimensions.' }
+  validates :dimension_range,               dimension: { width: { in: 800..1200 }, height: { in: 600..900 } }
+  validates :dimension_min,                 dimension: { min: 800..600 }
+  validates :dimension_max,                 dimension: { max: 1200..900 }
+  validates :dimension_images,              dimension: { width: { min: 800, max: 1200 }, height: { min: 600, max: 900 } }
 end

--- a/test/matchers/dimension_validator_matcher_test.rb
+++ b/test/matchers/dimension_validator_matcher_test.rb
@@ -47,6 +47,14 @@ class ActiveStorageValidations::Matchers::DimensionValidatorMatcher::Test < Acti
     assert matcher.matches?(Project)
   end
 
+  test 'width positive exact match with custom message' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_exact_with_message)
+    matcher.width 150
+    matcher.height 150
+    matcher.with_message('Invalid dimensions.')
+    assert matcher.matches?(Project)
+  end
+
   test 'width bigger than exact match' do
     matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_exact)
     matcher.width 999


### PR DESCRIPTION
The dimension validator matchers fail when a custom message is supplied.  This PR adds a `with_message` option to the matcher which will take precedence over the default message.