### PR TITLE
Raise error when undefined mime type symbol is given

### DIFF
--- a/lib/active_storage_validations/content_type_validator.rb
+++ b/lib/active_storage_validations/content_type_validator.rb
@@ -21,7 +21,14 @@ module ActiveStorageValidations
 
     def types
       (Array.wrap(options[:with]) + Array.wrap(options[:in])).compact.map do |type|
-        Mime[type] || type
+        if type.is_a?(Regexp)
+          type
+        elsif type.is_a?(String) && type =~ %r{\A\w+/[-+.\w]+\z} # mime-type-ish string
+          type
+        else
+          Mime[type] || raise(ArgumentError, "content_type must be one of Regxep,"\
+          " supported mime types (e.g. :png, 'jpg'), or mime type String ('image/jpeg')")
+        end
       end
     end
 

--- a/test/active_storage_validations_test.rb
+++ b/test/active_storage_validations_test.rb
@@ -90,6 +90,12 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     assert_equal u.errors.full_messages, ['Avatar has an invalid content type', 'Photos has an invalid content type']
   end
 
+  test 'invalid content_type validation setting' do
+    i = InvalidContentType.new(document: webp_file)
+    ex = assert_raises(ArgumentError) { i.valid? }
+    assert_equal ex.message, "content_type must be one of Regxep, supported mime types (e.g. :png, 'jpg'), or mime type String ('image/jpeg')"
+  end
+
   test 'validates size' do
     e = Project.new(title: 'Death Star')
     e.preview.attach(big_file)

--- a/test/dummy/app/models/invalid_content_type.rb
+++ b/test/dummy/app/models/invalid_content_type.rb
@@ -1,0 +1,5 @@
+class InvalidContentType < ApplicationRecord
+  has_one_attached :document
+
+  validates :document, content_type: %i[txt doc]
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -34,6 +34,9 @@ ActiveRecord::Schema.define do
     end
   end
 
+  create_table :invalid_content_types, force: :cascade do |t|
+  end
+
   create_table :limit_attachments, force: :cascade do |t|
     t.string :name
   end


### PR DESCRIPTION
I'm trying to close https://github.com/igorkasyanchuk/active_storage_validations/issues/109.

As described in the issue's comment, I changed `ContentTypeValidator` so that supplying a symbol for an undefined MIME type raises an error.