### PR TITLE
Enable to set message on error of attached validator

### DIFF
--- a/lib/active_storage_validations/attached_validator.rb
+++ b/lib/active_storage_validations/attached_validator.rb
@@ -5,7 +5,10 @@ module ActiveStorageValidations
     def validate_each(record, attribute, _value)
       return if record.send(attribute).attached?
 
-      record.errors.add(attribute, :blank)
+      errors_options = {}
+      errors_options[:message] = options[:message] if options[:message].present?
+
+      record.errors.add(attribute, :blank, **errors_options)
     end
   end
 end

--- a/test/active_storage_validations_test.rb
+++ b/test/active_storage_validations_test.rb
@@ -14,7 +14,7 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
   test 'validates presence' do
     u = User.new(name: 'John Smith')
     assert !u.valid?
-    assert_equal u.errors.full_messages, ["Avatar can't be blank", "Photos can't be blank"]
+    assert_equal u.errors.full_messages, ["Avatar must not be blank", "Photos can't be blank"]
 
     u = User.new(name: 'John Smith')
     u.avatar.attach(dummy_file)
@@ -24,7 +24,7 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     u = User.new(name: 'John Smith')
     u.photos.attach(dummy_file)
     assert !u.valid?
-    assert_equal u.errors.full_messages, ["Avatar can't be blank"]
+    assert_equal u.errors.full_messages, ["Avatar must not be blank"]
   end
 
   test 'validates content type' do

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
 
   validates :name, presence: true
 
-  validates :avatar, attached: true, content_type: :png
+  validates :avatar, attached: { message: "must not be blank" }, content_type: :png
   validates :photos, attached: true, content_type: ['image/png', 'image/jpg', /\A.*\/pdf\z/]
   validates :image_regex, content_type: /\Aimage\/.*\z/
   validates :conditional_image, attached: true, if: -> { name == 'Foo' }


### PR DESCRIPTION
This pull request tries to fix https://github.com/igorkasyanchuk/active_storage_validations/issues/86.