### PR TITLE
Replace deprecated .create_after_upload!

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ To run tests in root folder of gem:
 * `BUNDLE_GEMFILE=gemfiles/rails_5_2.gemfile bundle exec rake test` to run for Rails 5.2
 * `BUNDLE_GEMFILE=gemfiles/rails_6_0.gemfile bundle exec rake test` to run for Rails 6.0
 * `BUNDLE_GEMFILE=gemfiles/rails_6_1.gemfile bundle exec rake test` to run for Rails 6.1
+* `BUNDLE_GEMFILE=gemfiles/rails_next.gemfile bundle exec rake test` to run for Rails main branch
 
 ## Known issues
 

--- a/lib/active_storage_validations/aspect_ratio_validator.rb
+++ b/lib/active_storage_validations/aspect_ratio_validator.rb
@@ -18,7 +18,7 @@ module ActiveStorageValidations
       raise ArgumentError, 'You must pass "aspect_ratio: :OPTION" option to the validator'
     end
 
-    if Rails::VERSION::MAJOR >= 6
+    if Rails.gem_version >= Gem::Version.new('6.0.0')
       def validate_each(record, attribute, _value)
         return true unless record.send(attribute).attached?
 

--- a/lib/active_storage_validations/dimension_validator.rb
+++ b/lib/active_storage_validations/dimension_validator.rb
@@ -34,7 +34,7 @@ module ActiveStorageValidations
     end
 
 
-    if Rails::VERSION::MAJOR >= 6
+    if Rails.gem_version >= Gem::Version.new('6.0.0')
       def validate_each(record, attribute, _value)
         return true unless record.send(attribute).attached?
 

--- a/lib/active_storage_validations/matchers.rb
+++ b/lib/active_storage_validations/matchers.rb
@@ -22,7 +22,7 @@ module ActiveStorageValidations
     end
 
     def self.mock_metadata(attachment, width, height)
-      if Rails::VERSION::MAJOR >= 6
+      if Rails.gem_version >= Gem::Version.new('6.0.0')
         # Mock the Metadata class for rails 6
         mock = OpenStruct.new(metadata: { width: width, height: height })
         stub_method(ActiveStorageValidations::Metadata, :new, mock) do

--- a/lib/active_storage_validations/metadata.rb
+++ b/lib/active_storage_validations/metadata.rb
@@ -21,17 +21,16 @@ module ActiveStorageValidations
     def read_image
       is_string = file.is_a?(String)
       if is_string || file.is_a?(ActiveStorage::Blob)
-        if is_string
-          # If Rails 5.2 or 6.0, use `find_signed`
-          if Rails::VERSION::MAJOR < 6 || (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR == 0)
-            blob = ActiveStorage::Blob.find_signed(file)
-          # If Rails 6.1 or higher, use `find_signed!`
-          elsif Rails::VERSION::MAJOR > 6 || (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR >= 1)
-            blob = ActiveStorage::Blob.find_signed!(file)
+        blob =
+          if is_string
+            if Rails.gem_version < Gem::Version.new('6.1.0')
+              ActiveStorage::Blob.find_signed(file)
+            else
+              ActiveStorage::Blob.find_signed!(file)
+            end
+          else
+            file
           end
-        else
-          blob = file
-        end
 
         tempfile = Tempfile.new(["ActiveStorage-#{blob.id}-", blob.filename.extension_with_delimiter])
         tempfile.binmode

--- a/test/active_storage_validations_test.rb
+++ b/test/active_storage_validations_test.rb
@@ -150,7 +150,7 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
 
     assert_equal 6, la.files.count
 
-    if Rails.version < "6.0.0"
+    if Rails.gem_version < Gem::Version.new('6.0.0')
       assert_equal 6, la.files_blobs.count
     else
       assert_equal 0, la.files_blobs.count
@@ -158,7 +158,7 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
 
     assert_equal ['Files total number is out of range'], la.errors.full_messages
 
-    if Rails.version < "6.0.0"
+    if Rails.gem_version < Gem::Version.new('6.0.0')
       la.files.first.purge
       la.files.first.purge
       la.files.first.purge
@@ -289,7 +289,12 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     assert e.title, "Changed"
 
     assert_nil e.dimension_min.attachment
-    blob = ActiveStorage::Blob.create_after_upload!(**image_800x600_file)
+    blob =
+      if Rails.gem_version >= Gem::Version.new('6.1.0')
+        ActiveStorage::Blob.create_and_upload!(**image_800x600_file)
+      else
+        ActiveStorage::Blob.create_after_upload!(**image_800x600_file)
+      end
     e.dimension_min = blob.signed_id
     e.save!
     e.reload

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -21,12 +21,12 @@ ActiveRecord::Schema.define do
     t.datetime :created_at, null: false
     t.index %i[key], name: :index_active_storage_blobs_on_key, unique: true
 
-    if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1.0')
+    if Rails.gem_version >= Gem::Version.new('6.1.0')
       t.string :service_name, null: false
     end
   end
 
-  if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1.0')
+  if Rails.gem_version >= Gem::Version.new('6.1.0')
     create_table :active_storage_variant_records, force: :cascade do |t|
       t.bigint :blob_id, null: false
       t.string :variation_digest, null: false

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ ENV['RAILS_ENV'] = 'test'
 require 'combustion'
 Combustion.path = 'test/dummy'
 Combustion.initialize! :active_record, :active_storage, :active_job do
-  config.active_job.queue_adapter = :inline if Rails::VERSION::MAJOR >= 6
+  config.active_job.queue_adapter = :inline if Rails.gem_version >= Gem::Version.new('6.0.0')
 end
 
 # Load other test helpers


### PR DESCRIPTION
1. Use the same syntax and condition for `Rails.version`
2. Replace deprecated `Blob.create_after_upload!` with `Blob.create_and_upload!`