### PR TITLE
Try to fix bundle install failure

### DIFF
--- a/gemfiles/rails_next.gemfile.lock
+++ b/gemfiles/rails_next.gemfile.lock
@@ -87,7 +87,10 @@ PATH
   remote: ..
   specs:
     active_storage_validations (0.9.5)
-      rails (>= 5.2.0)
+      activejob (>= 5.2.0)
+      activemodel (>= 5.2.0)
+      activestorage (>= 5.2.0)
+      activesupport (>= 5.2.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
## Issue

`minitest` on CI fails
https://github.com/igorkasyanchuk/active_storage_validations/actions/runs/1029284988

![image](https://user-images.githubusercontent.com/1811616/128626612-3e74a92d-8fea-4cdd-9667-d12096eccbfe.png)

## Change

I've just run `cd gemfiles && bundle install --gemfile=./rails_next.gemfile` to generate the lock file again.