### PR TITLE
Add min_size and max_size to :file_size_out_of_range error message

### DIFF
--- a/lib/active_storage_validations/size_validator.rb
+++ b/lib/active_storage_validations/size_validator.rb
@@ -25,6 +25,9 @@ module ActiveStorageValidations
         next if content_size_valid?(file.blob.byte_size)
 
         errors_options[:file_size] = number_to_human_size(file.blob.byte_size)
+        errors_options[:min_size] = number_to_human_size(min_size)
+        errors_options[:max_size] = number_to_human_size(max_size)
+
         record.errors.add(attribute, :file_size_out_of_range, **errors_options)
         break
       end
@@ -42,6 +45,14 @@ module ActiveStorageValidations
       elsif options[:greater_than_or_equal_to].present?
         file_size >= options[:greater_than_or_equal_to]
       end
+    end
+
+    def min_size
+      options[:between]&.min || options[:greater_than] || options[:greater_than_or_equal_to]
+    end
+
+    def max_size
+      options[:between]&.max || options[:less_than] || options[:less_than_or_equal_to]
     end
   end
 end


### PR DESCRIPTION
Currently, the error message for an invalid file size can't include the expected min or max size of the file.

The error message only states:

>  "Attachment size %{file_size} is not between required range"

---

This PR allows using the interpolated variables `%{min_size}` and `%{max_size}` in the localized error message string.

Thus the error message can be customized by projects using this gem to look like this:

>  "Attachment size %{file_size} is larger than the required size %{max_size}"


## Future work

For now, the error message doesn't include the size information by default. The extra information must be added by projects using the gem.

In a future PR, I'd like to introduce new localized strings for "too large" and "too small" errors, which would allow to have the default error messages mention the string by default. (This is more work because of retro-compatibility concerns though).