### PR TITLE
Reference Marcel::EXTENSIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,15 @@ end
 
 ### More examples
 
-- Content type validation using symbols. In order to infer the correct mime type from the symbol, the types must be registered with `MimeMagic::EXTENSIONS`.
+- Content type validation using symbols. In order to infer the correct mime type from the symbol, the types must be registered with `Marcel::EXTENSIONS` (`MimeMagic::EXTENSIONS` for Rails <= 6.1.3).
 
 ```ruby
 class User < ApplicationRecord
   has_one_attached :avatar
   has_many_attached :photos
 
-  validates :avatar, attached: true, content_type: :png # MimeMagic.by_extension(:png).to_s => 'image/png'
+  validates :avatar, attached: true, content_type: :png # Marcel::Magic.by_extension(:png).to_s => 'image/png'
+                                                        # Rails <= 6.1.3; MimeMagic.by_extension(:png).to_s => 'image/png'
   # or
   validates :photos, attached: true, content_type: [:png, :jpg, :jpeg]
   # or


### PR DESCRIPTION
Active Storage 6.1.3.2 upgraded `marcel` to version 1.0, which removed the dependency on `mimemagic`. `MimeMagic::EXTENSIONS` and `MimeMagic.by_extension` have been replaced by `Marcel::EXTENSIONS` and `Marcel::Magic.by_extension` respectively. The README is updated accordingly, including notes for use with older versions.