### PR TITLE
Remove references to image/jpg content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ class User < ApplicationRecord
 
   validates :avatar, attached: true, content_type: 'image/png',
                                      dimension: { width: 200, height: 200 }
-  validates :photos, attached: true, content_type: ['image/png', 'image/jpg', 'image/jpeg'],
+  validates :photos, attached: true, content_type: ['image/png', 'image/jpeg'],
                                      dimension: { width: { min: 800, max: 2400 },
                                                   height: { min: 600, max: 1800 }, message: 'is not given between dimension' }
   validates :image, attached: true,
-                    content_type: ['image/png', 'image/jpg'],
+                    content_type: ['image/png', 'image/jpeg'],
                     aspect_ratio: :landscape
 end
 ```

--- a/test/dummy/app/models/only_image.rb
+++ b/test/dummy/app/models/only_image.rb
@@ -2,5 +2,5 @@ class OnlyImage < ApplicationRecord
   has_one_attached :image
   validates :image, dimension: { width: { min: 100, max: 2000 }, height: { min: 100, max: 1500 } },
                     aspect_ratio: :is_16_9,
-                    content_type: ['image/png', 'image/jpg']
+                    content_type: ['image/png', 'image/jpeg']
 end

--- a/test/matchers/content_type_validator_matcher_test.rb
+++ b/test/matchers/content_type_validator_matcher_test.rb
@@ -13,7 +13,7 @@ class ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher::Test < Ac
 
   test 'negative match when providing class' do
     matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:avatar)
-    matcher.allowing('image/jpg')
+    matcher.allowing('image/jpeg')
     refute matcher.matches?(User)
   end
 
@@ -32,7 +32,7 @@ class ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher::Test < Ac
 
   test 'negative match when providing instance' do
     matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:avatar)
-    matcher.allowing('image/jpg')
+    matcher.allowing('image/jpeg')
     refute matcher.matches?(User.new)
   end
 


### PR DESCRIPTION
This content type raises a deprecation warning on Rails 7.0

DEPRECATION WARNING: image/jpg is not a valid content type, it should
not be used when creating a blob, and support for it will be removed
in Rails 7.1. If you want to keep supporting this content type past
Rails 7.1, add it to `config.active_storage.variable_content_types`.

https://www.w3.org/Graphics/JPEG/