### PR TITLE
Fix a file extension issue in Metadata#read_image

### DIFF
--- a/lib/active_storage_validations/metadata.rb
+++ b/lib/active_storage_validations/metadata.rb
@@ -55,13 +55,13 @@ module ActiveStorageValidations
         tempfile.flush
         tempfile.rewind
 
-        image = if image_processor == :vips && Vips::get_suffixes.include?(File.extname(tempfile.path))
+        image = if image_processor == :vips && Vips::get_suffixes.include?(File.extname(tempfile.path).downcase)
                   Vips::Image.new_from_file(tempfile.path)
                 else
                   MiniMagick::Image.new(tempfile.path)
                 end
       else
-        image = if image_processor == :vips && Vips::get_suffixes.include?(File.extname(read_file_path))
+        image = if image_processor == :vips && Vips::get_suffixes.include?(File.extname(read_file_path).downcase)
                   Vips::Image.new_from_file(read_file_path)
                 else
                   MiniMagick::Image.new(read_file_path)


### PR DESCRIPTION
It turns out that `Vips::get_suffixes` only includes lowercase extensions. So, if you have a file with an extension eg. `.JPG`, the code would fall back to MiniMagick which is not desired.