### PR TITLE
Add simplecov as a Development dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test/dummy/storage/
 test/dummy/tmp/
 test/dummy/.byebug_history
 *.gem
+coverage/

--- a/active_storage_validations.gemspec
+++ b/active_storage_validations.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'marcel'
-  s.add_development_dependency 'simplecov', '~> 0.21.2'
+  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'globalid'
 end

--- a/active_storage_validations.gemspec
+++ b/active_storage_validations.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'marcel'
+  s.add_development_dependency 'simplecov', '~> 0.21.2'
 end

--- a/gemfiles/rails_5_2.gemfile.lock
+++ b/gemfiles/rails_5_2.gemfile.lock
@@ -51,6 +51,7 @@ GEM
       thor (>= 0.14.6)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    docile (1.4.0)
     erubi (1.10.0)
     ffi (1.15.5)
     globalid (0.4.2)
@@ -115,6 +116,12 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sqlite3 (1.4.2)
     thor (1.0.1)
     thread_safe (0.3.6)
@@ -139,6 +146,7 @@ DEPENDENCIES
   pry
   rubocop
   ruby-vips (>= 2.1.0)
+  simplecov (~> 0.21.2)
   sqlite3
 
 BUNDLED WITH

--- a/gemfiles/rails_6_0.gemfile.lock
+++ b/gemfiles/rails_6_0.gemfile.lock
@@ -148,7 +148,7 @@ DEPENDENCIES
   pry
   rubocop
   ruby-vips (>= 2.1.0)
-  simplecov (~> 0.21.2)
+  simplecov
   sqlite3
 
 BUNDLED WITH

--- a/gemfiles/rails_6_0.gemfile.lock
+++ b/gemfiles/rails_6_0.gemfile.lock
@@ -51,6 +51,7 @@ GEM
       thor (>= 0.14.6)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    docile (1.4.0)
     erubi (1.10.0)
     ffi (1.15.5)
     globalid (0.4.2)
@@ -115,6 +116,12 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sqlite3 (1.4.2)
     thor (1.0.1)
     thread_safe (0.3.6)
@@ -140,6 +147,7 @@ DEPENDENCIES
   pry
   rubocop
   ruby-vips (>= 2.1.0)
+  simplecov (~> 0.21.2)
   sqlite3
 
 BUNDLED WITH

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -53,6 +53,7 @@ GEM
       thor (>= 0.14.6)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    docile (1.4.0)
     erubi (1.10.0)
     ffi (1.15.5)
     globalid (0.4.2)
@@ -117,6 +118,12 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sqlite3 (1.4.2)
     thor (1.0.1)
     tzinfo (2.0.4)
@@ -141,6 +148,7 @@ DEPENDENCIES
   pry
   rubocop
   ruby-vips (>= 2.1.0)
+  simplecov (~> 0.21.2)
   sqlite3
 
 BUNDLED WITH

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -149,7 +149,7 @@ DEPENDENCIES
   pry
   rubocop
   ruby-vips (>= 2.1.0)
-  simplecov (~> 0.21.2)
+  simplecov
   sqlite3
 
 BUNDLED WITH

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -52,6 +52,7 @@ GEM
       thor (>= 0.14.6)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    docile (1.4.0)
     erubi (1.10.0)
     ffi (1.15.5)
     globalid (1.0.0)
@@ -110,6 +111,12 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sqlite3 (1.4.2)
     thor (1.2.1)
     tzinfo (2.0.4)
@@ -132,6 +139,7 @@ DEPENDENCIES
   pry
   rubocop
   ruby-vips (>= 2.1.0)
+  simplecov (~> 0.21.2)
   sqlite3
 
 BUNDLED WITH

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -140,7 +140,7 @@ DEPENDENCIES
   pry
   rubocop
   ruby-vips (>= 2.1.0)
-  simplecov (~> 0.21.2)
+  simplecov
   sqlite3
 
 BUNDLED WITH

--- a/gemfiles/rails_next.gemfile.lock
+++ b/gemfiles/rails_next.gemfile.lock
@@ -219,7 +219,7 @@ DEPENDENCIES
   rails!
   rubocop
   ruby-vips (>= 2.1.0)
-  simplecov (~> 0.21.2)
+  simplecov
   sqlite3
 
 BUNDLED WITH

--- a/gemfiles/rails_next.gemfile.lock
+++ b/gemfiles/rails_next.gemfile.lock
@@ -111,6 +111,7 @@ GEM
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     digest (3.1.0)
+    docile (1.4.0)
     erubi (1.10.0)
     ffi (1.15.5)
     globalid (1.0.0)
@@ -185,6 +186,12 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sqlite3 (1.4.2)
     strscan (3.0.1)
     thor (1.2.1)
@@ -211,6 +218,7 @@ DEPENDENCIES
   rails!
   rubocop
   ruby-vips (>= 2.1.0)
+  simplecov (~> 0.21.2)
   sqlite3
 
 BUNDLED WITH

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+SimpleCov.start
+
+# Previous content of test helper now starts here
+
 # Configure Rails Environment
 ENV['RAILS_ENV'] = 'test'
 


### PR DESCRIPTION
Added [`simplecov`](https://github.com/simplecov-ruby/simplecov) as per [this](https://github.com/igorkasyanchuk/active_storage_validations/pull/152#issuecomment-1100852295) comment.