### PR TITLE
Fix proc unfolding scope

### DIFF
--- a/lib/active_storage_validations/option_proc_unfolding.rb
+++ b/lib/active_storage_validations/option_proc_unfolding.rb
@@ -1,10 +1,10 @@
 module ActiveStorageValidations
   module OptionProcUnfolding
 
-    def unfold_procs(record, object, only_keys = nil)
+    def unfold_procs(record, object, only_keys)
       case object
       when Hash
-        object.merge(object) { |key, value| only_keys&.exclude?(key) ? unfold_procs(record, value, []) : unfold_procs(record, value) }
+        object.merge(object) { |key, value| only_keys&.exclude?(key) ? {} : unfold_procs(record, value, nil) }
       when Array
         object.map { |o| unfold_procs(record, o, only_keys) }
       else

--- a/test/active_storage_validations_test.rb
+++ b/test/active_storage_validations_test.rb
@@ -91,6 +91,24 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     u.proc_photos.attach(bad_dummy_file)
     assert !u.valid?
     assert_equal u.errors.full_messages, ['Avatar has an invalid content type', 'Photos has an invalid content type', 'Image regex has an invalid content type', 'Proc avatar has an invalid content type', 'Proc photos has an invalid content type', 'Proc image regex has an invalid content type']
+
+    u = User.new(name: 'Peter Griffin')
+    u.avatar.attach(dummy_file)
+    u.proc_avatar.attach(dummy_file)
+    u.photos.attach(dummy_file)
+    u.proc_photos.attach(dummy_file)
+    u.conditional_image_2.attach(dummy_file)
+    assert u.valid?
+    assert_equal u.errors.full_messages, []
+
+    u = User.new(name: 'Peter Griffin')
+    u.avatar.attach(bad_dummy_file)
+    u.proc_avatar.attach(bad_dummy_file)
+    u.photos.attach(bad_dummy_file)
+    u.proc_photos.attach(dummy_file)
+    u.conditional_image_2.attach(bad_dummy_file)
+    assert !u.valid?
+    assert_equal u.errors.full_messages, ["Avatar has an invalid content type", "Photos has an invalid content type", "Conditional image 2 has an invalid content type", "Proc avatar has an invalid content type"]
   end
 
   # reads content type from file, not from webp_file_wrong method

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   has_many_attached :photos
   has_one_attached :image_regex
   has_one_attached :conditional_image
+  has_one_attached :conditional_image_2
   has_one_attached :proc_avatar
   has_many_attached :proc_photos
   has_one_attached :proc_image_regex
@@ -23,6 +24,7 @@ class User < ApplicationRecord
   validates :photos, attached: true, content_type: ['image/png', 'image/jpg', /\A.*\/pdf\z/]
   validates :image_regex, content_type: /\Aimage\/.*\z/
   validates :conditional_image, attached: true, if: -> { name == 'Foo' }
+  validates :conditional_image_2, attached: true, content_type: -> (record) {[/\Aimage\/.*\z/]}, size: { less_than: 10.megabytes }, if: -> { name == 'Peter Griffin' }
   validates :proc_avatar, attached: { message: "must not be blank" }, content_type: -> (record) {:png}
   validates :proc_photos, attached: true, content_type: -> (record) {['image/png', 'image/jpg', /\A.*\/pdf\z/]}
   validates :proc_image_regex, content_type: -> (record) {/\Aimage\/.*\z/}


### PR DESCRIPTION
Fixes bug where attributes not belonging to the validator were accidentally unfolded. This affected `if` and `unless` parameters, when using it like this, for example:
```ruby
validates :avatar, content_type: ALLOWED_CONTENT_TYPES, size: { less_than: 10.megabytes }, if: -> { attachment_changes['avatar'] }
```

Fixes #166 