### PR TITLE
Add processable image validator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 - master
-  ...
+  - add ProcessableImageValidator
 
 - 1.0.0
   - allow Procs as an input for validation options https://github.com/igorkasyanchuk/active_storage_validations/pull/135/files

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This gems doing it for you. Just use `attached: true` or `content_type: 'image/p
 * validates dimension of images/videos
 * validates number of uploaded files (min/max required)
 * validates aspect ratio (if square, portrait, landscape, is_16_9, ...)
+* validates if file can be processed by MiniMagick or Vips
 * custom error messages
 * allow procs for dynamic determination of values
 
@@ -40,6 +41,7 @@ class User < ApplicationRecord
                                      dimension: { width: { min: 800, max: 2400 },
                                                   height: { min: 600, max: 1800 }, message: 'is not given between dimension' }
   validates :image, attached: true,
+                    processable_image: true,
                     content_type: ['image/png', 'image/jpeg'],
                     aspect_ratio: :landscape
 end
@@ -164,6 +166,7 @@ en:
       aspect_ratio_not_landscape: "must be a landscape image"
       aspect_ratio_is_not: "must have an aspect ratio of %{aspect_ratio}"
       aspect_ratio_unknown: "has an unknown aspect ratio"
+      image_not_processable: "is not a valid image"
 ```
 
 In some cases, Active Storage Validations provides variables to help you customize messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,3 +20,4 @@ en:
       aspect_ratio_not_landscape: "must be a landscape image"
       aspect_ratio_is_not: "must have an aspect ratio of %{aspect_ratio}"
       aspect_ratio_unknown: "has an unknown aspect ratio"
+      image_not_processable: "is not a valid image"

--- a/lib/active_storage_validations.rb
+++ b/lib/active_storage_validations.rb
@@ -9,6 +9,7 @@ require 'active_storage_validations/size_validator'
 require 'active_storage_validations/limit_validator'
 require 'active_storage_validations/dimension_validator'
 require 'active_storage_validations/aspect_ratio_validator'
+require 'active_storage_validations/processable_image_validator'
 
 ActiveSupport.on_load(:active_record) do
   send :include, ActiveStorageValidations

--- a/lib/active_storage_validations/metadata.rb
+++ b/lib/active_storage_validations/metadata.rb
@@ -1,5 +1,7 @@
 module ActiveStorageValidations
   class Metadata
+    class InvalidImageError < StandardError; end
+
     attr_reader :file
 
     def initialize(file)
@@ -10,7 +12,7 @@ module ActiveStorageValidations
     def image_processor
       Rails.application.config.active_storage.variant_processor
     end
-    
+
     def exception_class
       if image_processor == :vips && defined?(Vips)
         Vips::Error
@@ -35,6 +37,16 @@ module ActiveStorageValidations
           { width: image.width, height: image.height }
         end
       end
+    rescue InvalidImageError
+      logger.info "Skipping image analysis because ImageMagick or Vips doesn't support the file"
+      {}
+    end
+
+    def valid?
+      read_image
+      true
+    rescue InvalidImageError
+      false
     end
 
     private
@@ -76,12 +88,9 @@ module ActiveStorageValidations
                 end
       end
 
-      if image && valid_image?(image)
-        yield image
-      else
-        logger.info "Skipping image analysis because ImageMagick or Vips doesn't support the file"
-        {}
-      end
+
+      raise InvalidImageError unless valid_image?(image)
+      yield image
     rescue LoadError, NameError
       logger.info "Skipping image analysis because the mini_magick or ruby-vips gem isn't installed"
       {}
@@ -93,6 +102,8 @@ module ActiveStorageValidations
     end
 
     def valid_image?(image)
+      return false unless image
+
       image_processor == :vips && image.is_a?(Vips::Image) ? image.avg : image.valid?
     rescue exception_class
       false

--- a/lib/active_storage_validations/processable_image_validator.rb
+++ b/lib/active_storage_validations/processable_image_validator.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative 'metadata.rb'
+
+module ActiveStorageValidations
+  class ProcessableImageValidator < ActiveModel::EachValidator # :nodoc
+    include OptionProcUnfolding
+
+    if Rails.gem_version >= Gem::Version.new('6.0.0')
+      def validate_each(record, attribute, _value)
+        return true unless record.send(attribute).attached?
+
+        changes = record.attachment_changes[attribute.to_s]
+        return true if changes.blank?
+
+        files = Array.wrap(changes.is_a?(ActiveStorage::Attached::Changes::CreateMany) ? changes.attachables : changes.attachable)
+
+        files.each do |file|
+          add_error(record, attribute, :image_not_processable) unless Metadata.new(file).valid?
+        end
+      end
+    else
+      # Rails 5
+      def validate_each(record, attribute, _value)
+        return true unless record.send(attribute).attached?
+
+        files = Array.wrap(record.send(attribute))
+
+        files.each do |file|
+          add_error(record, attribute, :image_not_processable) unless Metadata.new(file).valid?
+        end
+      end
+    end
+
+    private
+
+    def add_error(record, attribute, default_message)
+      message = options[:message].presence || default_message
+      return if record.errors.added?(attribute, message)
+      record.errors.add(attribute, message)
+    end
+  end
+end

--- a/test/active_storage_validations_test.rb
+++ b/test/active_storage_validations_test.rb
@@ -271,6 +271,19 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     e.proc_image.attach(pdf_file)
     assert !e.valid?
     assert e.errors.full_messages.include?("Image has an invalid content type")
+
+    e = OnlyImage.new
+    e.image.attach(image_1920x1080_file)
+    e.proc_image.attach(image_1920x1080_file)
+    e.another_image.attach(tar_file_with_image_content_type)
+    assert !e.valid?
+    assert_equal e.errors.full_messages, ["Another image is not a valid image"]
+
+    e = OnlyImage.new
+    e.image.attach(image_1920x1080_file)
+    e.proc_image.attach(image_1920x1080_file)
+    e.any_image.attach(tar_file_with_image_content_type)
+    assert e.valid?
   rescue Exception => ex
     puts ex.message
     puts ex.backtrace.take(20).join("\n")
@@ -555,4 +568,8 @@ end
 
 def tar_file
   { io: File.open(Rails.root.join('public', '404.html.tar')), filename: '404.html.tar', content_type: 'application/x-tar' }
+end
+
+def tar_file_with_image_content_type
+  { io: File.open(Rails.root.join('public', '404.html.tar')), filename: '404.png', content_type: 'image/png' }
 end

--- a/test/dummy/app/models/only_image.rb
+++ b/test/dummy/app/models/only_image.rb
@@ -1,10 +1,15 @@
 class OnlyImage < ApplicationRecord
   has_one_attached :image
   has_one_attached :proc_image
+  has_one_attached :another_image
+  has_one_attached :any_image
+
   validates :image, dimension: { width: { min: 100, max: 2000 }, height: { min: 100, max: 1500 } },
                     aspect_ratio: :is_16_9,
                     content_type: ['image/png', 'image/jpeg']
   validates :proc_image, dimension: { width: { min: -> (record) {100}, max: -> (record) {2000} }, height: { min: -> (record) {100}, max: -> (record) {1500} } },
             aspect_ratio: -> (record) {:is_16_9},
             content_type: -> (record) {['image/png', 'image/jpeg']}
+  validates :another_image, processable_image: true
+  validates :any_image, processable_image: false
 end


### PR DESCRIPTION
Content type validation isn't enough to ensure that what users upload is an image and can be manipulated by MiniMagick or Vips. So my idea is to add additional validator which can check if a file can be processed by the library. 

For simplicity, I used `Metadata` class which has necessary methods. It probably should be extracted to separate class but I didn't want to make a huge refactor along the way

It should solve the following issues:
https://github.com/igorkasyanchuk/active_storage_validations/issues/91
https://github.com/igorkasyanchuk/active_storage_validations/issues/62
https://github.com/igorkasyanchuk/active_storage_validations/issues/130 (partially, since it's only for images, for all other files we can extend ContentTypeValidator to read a file and use `Marcel::MimeType.for`)