### PR TITLE
Support using allowing and rejecting together on content type matcher

### DIFF
--- a/lib/active_storage_validations/matchers/content_type_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/content_type_validator_matcher.rb
@@ -19,13 +19,11 @@ module ActiveStorageValidations
 
       def allowing(*types)
         @allowed_types = types.flatten
-        either_allowing_or_rejecting
         self
       end
 
       def rejecting(*types)
         @rejected_types = types.flatten
-        either_allowing_or_rejecting
         self
       end
 
@@ -51,12 +49,6 @@ module ActiveStorageValidations
       end
 
       protected
-
-      def either_allowing_or_rejecting
-        if @allowed_types && @rejected_types
-          raise ArgumentError, "You must specify either allowing or rejecting"
-        end
-      end
 
       def responds_to_methods
         @subject.respond_to?(@attribute_name) &&

--- a/test/matchers/content_type_validator_matcher_test.rb
+++ b/test/matchers/content_type_validator_matcher_test.rb
@@ -63,4 +63,10 @@ class ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher::Test < Ac
     matcher.rejecting('image/png')
     refute matcher.matches?(User)
   end
+
+  test 'positive match on subset of accepted content types' do
+    matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:photos)
+    matcher.allowing('image/png')
+    assert matcher.matches?(User)
+  end
 end

--- a/test/matchers/content_type_validator_matcher_test.rb
+++ b/test/matchers/content_type_validator_matcher_test.rb
@@ -51,4 +51,16 @@ class ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher::Test < Ac
     matcher.allowing('image/png')
     refute matcher.matches?(User.new)
   end
+
+  test 'positive match for rejecting' do
+    matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:avatar)
+    matcher.rejecting('image/jpeg')
+    assert matcher.matches?(User)
+  end
+
+  test 'negative match for rejecting' do
+    matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:avatar)
+    matcher.rejecting('image/png')
+    refute matcher.matches?(User)
+  end
 end

--- a/test/matchers/content_type_validator_matcher_test.rb
+++ b/test/matchers/content_type_validator_matcher_test.rb
@@ -4,16 +4,20 @@ require 'test_helper'
 require 'active_storage_validations/matchers'
 
 class ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher::Test < ActiveSupport::TestCase
-  test 'positive and negative' do
+  test 'positive match on both allowing and rejecting' do
     matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:avatar)
     matcher.allowing('image/png')
-    assert_raise(ArgumentError) { matcher.rejecting('image/jpg') }
+    matcher.rejecting('image/jpg')
+
+    assert matcher.matches?(User)
   end
 
-  test 'negative and positive' do
+  test 'negative match on both allowing and rejecting' do
     matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:avatar)
     matcher.rejecting('image/png')
-    assert_raise(ArgumentError) { matcher.allowing('image/jpg') }
+    matcher.allowing('image/jpg')
+
+    refute matcher.matches?(User)
   end
 
   test 'positive match when providing class' do


### PR DESCRIPTION
The changes in version 1.0.1 blocked the option of specifying both `allowing` and `rejecting` on the content type matcher. It turns out this was not necessary for fixing the slowness, since that was caused by the default value of `rejecting` using the `Marcel` types.

This changes adds back the option of using `allowing` and `rejecting` together.