### PR TITLE
Support StringIO attachments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_storage_validations (1.0.2)
+    active_storage_validations (1.0.3)
       activejob (>= 5.2.0)
       activemodel (>= 5.2.0)
       activestorage (>= 5.2.0)

--- a/test/active_storage_validations_test.rb
+++ b/test/active_storage_validations_test.rb
@@ -309,6 +309,15 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     raise ex
   end
 
+  test 'dimensions with attached StringIO' do
+    e = OnlyImage.new
+    e.image.attach(image_string_io)
+    e.proc_image.attach(image_string_io)
+    e.another_image.attach(image_string_io)
+    e.any_image.attach(image_string_io)
+    assert e.valid?
+  end
+
   test 'dimensions test' do
     e = Project.new(title: 'Death Star')
     e.preview.attach(big_file)
@@ -591,4 +600,11 @@ end
 
 def tar_file_with_image_content_type
   { io: File.open(Rails.root.join('public', '404.html.tar')), filename: '404.png', content_type: 'image/png' }
+end
+
+def image_string_io
+  string_io = StringIO.new().tap {|io| io.binmode }
+  IO.copy_stream(File.open(Rails.root.join('public', 'image_1920x1080.png')), string_io)
+  string_io.rewind
+  { io: string_io, filename: 'image_1920x1080.png', content_type: 'image/png' }
 end


### PR DESCRIPTION
Hello!
I run into another issue. Take a look at the code copied from my app:

```
downloaded_image = ::OpenURI.open_uri(some_url)
uri = ::URI.parse(some_url)

user.avatar.attach(io: downloaded_image, filename: File.basename(uri.path))
```

If a fetched file is smaller than 10kb (or something like that, I don't remember) `downloaded_image` will be a StringIO, not a Tempfile. ActiveStorage supports it so `active_support_validations` should too but it doesn't. It's raising `no implicit conversion of StringIO into String` error.

So to fix that I copy StringIO to Tempfile before pushing it to MiniMagick of Vips. I tried to make it work without additional file but MiniMagick creates it underneath anyway and Vips didn't cooperate :)