### PR TITLE
[Validations] Validations fail when using dimension: { min: 1080..1080 } syntax

### DIFF
--- a/lib/active_storage_validations/matchers/dimension_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/dimension_validator_matcher.rb
@@ -65,8 +65,8 @@ module ActiveStorageValidations
       def matches?(subject)
         @subject = subject.is_a?(Class) ? subject.new : subject
         responds_to_methods &&
-          width_smaller_than_min? && width_larger_than_min? && width_smaller_than_max? && width_larger_than_max? && width_equals? &&
-          height_smaller_than_min? && height_larger_than_min? && height_smaller_than_max? && height_larger_than_max? && height_equals?
+          width_not_smaller_than_min? && width_larger_than_min? && width_smaller_than_max? && width_not_larger_than_max? && width_equals? &&
+          height_not_smaller_than_min? && height_larger_than_min? && height_smaller_than_max? && height_not_larger_than_max? && height_equals?
       end
 
       def failure_message
@@ -93,7 +93,7 @@ module ActiveStorageValidations
         ((@height_min || 0) + (@height_max || 2000)) / 2
       end
 
-      def width_smaller_than_min?
+      def width_not_smaller_than_min?
         @width_min.nil? || !passes_validation_with_dimensions(@width_min - 1, valid_height, 'width')
       end
 
@@ -105,7 +105,7 @@ module ActiveStorageValidations
         @width_max.nil? || @width_min == @width_max || passes_validation_with_dimensions(@width_max - 1, valid_height, 'width')
       end
 
-      def width_larger_than_max?
+      def width_not_larger_than_max?
         @width_max.nil? || !passes_validation_with_dimensions(@width_max + 1, valid_height, 'width')
       end
 
@@ -113,7 +113,7 @@ module ActiveStorageValidations
         @width_min.nil? || @width_min != @width_max || passes_validation_with_dimensions(@width_min, valid_height, 'width')
       end
 
-      def height_smaller_than_min?
+      def height_not_smaller_than_min?
         @height_min.nil? || !passes_validation_with_dimensions(valid_width, @height_min - 1, 'height')
       end
 
@@ -125,7 +125,7 @@ module ActiveStorageValidations
         @height_max.nil? || @height_min == @height_max || passes_validation_with_dimensions(valid_width, @height_max - 1, 'height')
       end
 
-      def height_larger_than_max?
+      def height_not_larger_than_max?
         @height_max.nil? || !passes_validation_with_dimensions(valid_width, @height_max + 1, 'height')
       end
 
@@ -140,10 +140,10 @@ module ActiveStorageValidations
         Matchers.mock_metadata(attachment, width, height) do
           @subject.validate
           exclude_error_message = @custom_message || "dimension_#{check}"
-          @subject.errors.details[@attribute_name].all? do |error|
-            error[:error].to_s.exclude?(exclude_error_message) &&
-            error[:error].to_s.exclude?("dimension_min") &&
-            error[:error].to_s.exclude?("dimension_max")
+          @subject.errors.details[@attribute_name].none? do |error|
+            error[:error].to_s.include?(exclude_error_message) ||
+            error[:error].to_s.include?("dimension_min") ||
+            error[:error].to_s.include?("dimension_max")
           end
         end
       end

--- a/lib/active_storage_validations/matchers/dimension_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/dimension_validator_matcher.rb
@@ -140,7 +140,11 @@ module ActiveStorageValidations
         Matchers.mock_metadata(attachment, width, height) do
           @subject.validate
           exclude_error_message = @custom_message || "dimension_#{check}"
-          @subject.errors.details[@attribute_name].all? { |error| error[:error].to_s.exclude?(exclude_error_message) }
+          @subject.errors.details[@attribute_name].all? do |error|
+            error[:error].to_s.exclude?(exclude_error_message) &&
+            error[:error].to_s.exclude?("dimension_min") &&
+            error[:error].to_s.exclude?("dimension_max")
+          end
         end
       end
 

--- a/test/matchers/dimension_validator_matcher_test.rb
+++ b/test/matchers/dimension_validator_matcher_test.rb
@@ -143,4 +143,62 @@ class ActiveStorageValidations::Matchers::DimensionValidatorMatcher::Test < Acti
     matcher.width_min 800
     refute matcher.matches?(Project.new)
   end
+
+  # width_min and height_min combined
+  test 'both width_min and height_min on higher combined are a positive match' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_min)
+    matcher.width_min 800
+    matcher.height_min 600
+    assert matcher.matches?(Project)
+  end
+
+  test 'width_min less than lower and height_min on higher combined are a negative match' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_min)
+    matcher.width_min 700
+    matcher.height_min 600
+    refute matcher.matches?(Project)
+  end
+
+  test 'width_min on higher and height_min less than lower combined are a negative match' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_min)
+    matcher.width_min 800
+    matcher.height_min 500
+    refute matcher.matches?(Project)
+  end
+
+  test 'both width_min and height_min less than lower combined are a negative match' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_min)
+    matcher.width_min 700
+    matcher.height_min 500
+    refute matcher.matches?(Project)
+  end
+
+  # width_max and height_max combined
+  test 'both width_max and height_max on higher combined are a positive match' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_max)
+    matcher.width_max 1200
+    matcher.height_max 900
+    assert matcher.matches?(Project)
+  end
+
+  test 'width_max higher than higher and height_max on higher combined are a negative match' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_max)
+    matcher.width_max 1500
+    matcher.height_max 900
+    refute matcher.matches?(Project)
+  end
+
+  test 'width_max on higher and height_max higher than higher combined are a negative match' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_max)
+    matcher.width_max 1200
+    matcher.height_max 1100
+    refute matcher.matches?(Project)
+  end
+
+  test 'both width_max and height_max higher than higher combined are a negative match' do
+    matcher = ActiveStorageValidations::Matchers::DimensionValidatorMatcher.new(:dimension_max)
+    matcher.width_min 1500
+    matcher.height_max 1100
+    refute matcher.matches?(Project)
+  end
 end


### PR DESCRIPTION
Closes #163 

This PR has 2 commits :
- [[Bugfix] Correct test fail using 'dimension: { min: 1080..1080 }'](https://github.com/igorkasyanchuk/active_storage_validations/commit/8da49577bd9bcf8d7d0b23699f9e38065a65f33c) => fixes #163 
- [[DimensionValidator] Make semantic changes for better understanding](https://github.com/igorkasyanchuk/active_storage_validations/commit/810f8eb8f0a4f405fef263b9200d394c41f7022f) => makes semantic changes for better understanding

The second commit is optional, though I think it's a good thing to change some methods & calls for making contributing slightly easier

Open to discussion, I would like to contribute further to this amazing project that you made @igorkasyanchuk ;)
