### PR TITLE
fix minitest yaml syntax for ruby versions

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -6,10 +6,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.6
-          - 2.7
-          - 3.0
-          - 3.1
+          - '2.6'
+          - '2.7'
+          - '3.0'
+          - '3.1'
         gemfile:
           - rails_6_0
           - rails_6_1
@@ -20,18 +20,18 @@ jobs:
           - mini_magick
         exclude:
           # ruby 3.1 only supports rails 7.0+
-          - ruby: 3.1
+          - ruby: '3.1'
             gemfile: rails_6_0
-          - ruby: 3.1
+          - ruby: '3.1'
             gemfile: rails_6_1
           # ruby 3 only supports rails 6.1+
           - ruby: '3.0'
             gemfile: rails_6_0
           # rails 7.0 only supports ruby 2.7+
-          - ruby: 2.6
+          - ruby: '2.6'
             gemfile: rails_7_0
           # rails next only supports ruby 2.7+
-          - ruby: 2.6
+          - ruby: '2.6'
             gemfile: rails_next
     runs-on: ubuntu-latest
     steps:
@@ -55,3 +55,4 @@ jobs:
 
       - name: Run tests
         run: bundle exec rake test
+


### PR DESCRIPTION
Use strings for ruby versions so yaml will never interpret them numerically.

Ruby 3.2 was released recently so an error testing "Ruby 3" occurred - it was supposed to test against "Ruby 3.0" but used Ruby 3.1, now Ruby 3.2. This fixes the yaml file by using strings for ruby versions anywhere.