### PR TITLE
Support libvips < 8.8

### DIFF
--- a/lib/active_storage_validations/metadata.rb
+++ b/lib/active_storage_validations/metadata.rb
@@ -75,18 +75,10 @@ module ActiveStorageValidations
         tempfile.flush
         tempfile.rewind
 
-        image = if image_processor == :vips && defined?(Vips) && Vips::get_suffixes.include?(File.extname(tempfile.path).downcase)
-                  Vips::Image.new_from_file(tempfile.path)
-                elsif defined?(MiniMagick)
-                  MiniMagick::Image.new(tempfile.path)
-                end
+        image = new_image_from_path(tempfile.path)
       else
         file_path = read_file_path
-        image = if image_processor == :vips && defined?(Vips) && Vips::get_suffixes.include?(File.extname(file_path).downcase)
-                  Vips::Image.new_from_file(file_path)
-                elsif defined?(MiniMagick)
-                  MiniMagick::Image.new(file_path)
-                end
+        image = new_image_from_path(file_path)
       end
 
 
@@ -100,6 +92,14 @@ module ActiveStorageValidations
       {}
     ensure
       image = nil
+    end
+
+    def new_image_from_path(path)
+      if image_processor == :vips && defined?(Vips) && (Vips::get_suffixes.include?(File.extname(path).downcase) || !Vips::respond_to?(:vips_foreign_get_suffixes))
+        Vips::Image.new_from_file(path)
+      elsif defined?(MiniMagick)
+        MiniMagick::Image.new(path)
+      end
     end
 
     def valid_image?(image)


### PR DESCRIPTION
If you try to validate images while using libvips 8.7 every image fails validation with an "is not a valid image" error. This was helpfully investigated by @marckohlbrugge in #170 and seems to be caused because libvips can't report which file types it supports in versions below 8.8.

I've changed the code so it checks to see whether libvips can report the file types. I've assumed that if we have libvips installed and it can't report the supported file types then we should still use libvips. This might mean we raise errors if we give vips a file it does not support but I can't see another (easy) way to support older versions of libvips.