### PR TITLE
Explicitly require active_model before using it

### DIFF
--- a/lib/active_storage_validations.rb
+++ b/lib/active_storage_validations.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_model'
+
 require 'active_storage_validations/railtie'
 require 'active_storage_validations/engine'
 require 'active_storage_validations/option_proc_unfolding'


### PR DESCRIPTION


There are some cases where rails hasn't been fully initialized by the time active_storage_validations is required. In those cases, there are active_model classes in this library that are used before `active_model` has been required.

This fixes it by requiring it in the main file.

fixes https://github.com/igorkasyanchuk/active_storage_validations/issues/197