### PR TITLE
[Matcher] Fix misbehaviour on validate_content_type_of matcher (#201)

### DIFF
--- a/lib/active_storage_validations/matchers/content_type_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/content_type_validator_matcher.rb
@@ -35,7 +35,7 @@ module ActiveStorageValidations
 
       def matches?(subject)
         @subject = subject.is_a?(Class) ? subject.new : subject
-        responds_to_methods && allowed_types_allowed? && rejected_types_rejected? && validate_error_message?
+        responds_to_methods && allowed_types_allowed? && rejected_types_rejected? && validate_custom_message?
       end
 
       def failure_message
@@ -88,10 +88,12 @@ module ActiveStorageValidations
         end
       end
 
-      def validate_error_message?
+      def validate_custom_message?
+        return true unless @custom_message
+
         @subject.public_send(@attribute_name).attach(attachment_for('fake/fake'))
         @subject.validate
-        @subject.errors.details[@attribute_name].all? do |error|
+        @subject.errors.details[@attribute_name].select{|error| error[:content_type]}.all? do |error|
           error[:error].to_s.include?(error_message)
         end
       end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
   has_one_attached :image_regex
   has_one_attached :conditional_image
   has_one_attached :conditional_image_2
+  has_one_attached :moon_picture
   has_one_attached :proc_avatar
   has_many_attached :proc_photos
   has_many_attached :proc_photo_with_messages
@@ -28,6 +29,8 @@ class User < ApplicationRecord
   validates :image_regex, content_type: /\Aimage\/.*\z/
   validates :conditional_image, attached: true, if: -> { name == 'Foo' }
   validates :conditional_image_2, attached: true, content_type: -> (record) {[/\Aimage\/.*\z/]}, size: { less_than: 10.megabytes }, if: -> { name == 'Peter Griffin' }
+
+  validates :moon_picture, content_type: ['image/png'], size: { greater_than: 0 }
 
   validates :proc_avatar, attached: { message: "must not be blank" }, content_type: -> (record) {:png}
   validates :proc_photos, attached: true, content_type: -> (record) {['image/png', 'image/jpg', /\A.*\/pdf\z/]}

--- a/test/matchers/content_type_validator_matcher_test.rb
+++ b/test/matchers/content_type_validator_matcher_test.rb
@@ -74,6 +74,12 @@ class ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher::Test < Ac
     assert matcher.matches?(User)
   end
 
+  test 'matches when combined with a another validator which has errors (file size = 0)' do
+    matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:moon_picture)
+    matcher.allowing('image/png')
+    assert matcher.matches?(User)
+  end
+
   class WithMessageMatcher < ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher::Test
     test 'matches when provided with the model validation message' do
       matcher = ActiveStorageValidations::Matchers::ContentTypeValidatorMatcher.new(:photo_with_messages)


### PR DESCRIPTION
Closes #201 

The error was due to #183 that implemented a check on the `custom_message` matcher for `content_type`.
It was:
- always looking to check the validity of the `custom_message` matcher even if not present
- looking on all errors of the field (meaning not content_type errors also) to find this message

Both these behaviours have been removed.