### PR TITLE
Add `image_not_processable` localization

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_storage_validations (1.1.0)
+    active_storage_validations (1.1.1)
       activejob (>= 5.2.0)
       activemodel (>= 5.2.0)
       activestorage (>= 5.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_storage_validations (1.1.1)
+    active_storage_validations (1.1.0)
       activejob (>= 5.2.0)
       activemodel (>= 5.2.0)
       activestorage (>= 5.2.0)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -24,3 +24,4 @@ de:
       aspect_ratio_not_landscape: "muss Querformat sein"
       aspect_ratio_is_not: "muss ein Bildseitenverhältnis von %{aspect_ratio} haben"
       aspect_ratio_unknown: "hat ein unbekanntes Bildseitenverhältnis"
+      image_not_processable: "ist kein gültiges Bild"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -24,3 +24,4 @@ es:
       aspect_ratio_not_landscape: "debe ser una imagen apaisada"
       aspect_ratio_is_not: "debe tener una relación de aspecto de %{aspect_ratio}"
       aspect_ratio_unknown: "tiene una relación de aspecto desconocida"
+      image_not_processable: "no es una imagen válida"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -24,3 +24,4 @@ fr:
       aspect_ratio_not_landscape: "doit être une image en format paysage"
       aspect_ratio_is_not: "doit avoir un rapport hauteur / largeur de %{aspect_ratio}"
       aspect_ratio_unknown: "a un rapport d'aspect inconnu"
+      image_not_processable: "n'est pas une image valide"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -24,3 +24,4 @@ it:
       aspect_ratio_not_landscape: "l’orientamento dell’immagine deve essere orizzontale"
       aspect_ratio_is_not: "deve avere un rapporto altezza / larghezza di %{aspect_ratio}"
       aspect_ratio_unknown: "ha un rapporto altezza / larghezza sconosciuto"
+      image_not_processable: "non è un'immagine valida"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,3 +24,4 @@ ja:
       aspect_ratio_not_landscape: "は横長にしてください"
       aspect_ratio_is_not: "のアスペクト比は %{aspect_ratio} にしてください"
       aspect_ratio_unknown: "のアスペクト比を取得できませんでした"
+      image_not_processable: "は不正な画像です"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -24,3 +24,4 @@ nl:
       aspect_ratio_not_landscape: "moet een liggende afbeelding zijn"
       aspect_ratio_is_not: "moet een beeldverhouding hebben van %{aspect_ratio}"
       aspect_ratio_unknown: "heeft een onbekende beeldverhouding"
+      image_not_processable: "is geen geldige afbeelding"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -24,3 +24,4 @@ pl:
       aspect_ratio_not_landscape: "musi mieć proporcje pejzażu"
       aspect_ratio_is_not: "musi mieć proporcje %{aspect_ratio}"
       aspect_ratio_unknown: "ma nieokreślone proporcje"
+      image_not_processable: "nie jest prawidłowym obrazem"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -24,3 +24,4 @@ ru:
       aspect_ratio_not_landscape: "должно быть пейзажное изображение"
       aspect_ratio_is_not: "должен иметь соотношение сторон %{aspect_ratio}"
       aspect_ratio_unknown: "имеет неизвестное соотношение сторон"
+      image_not_processable: "не является допустимым изображением"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -24,3 +24,4 @@ tr:
       aspect_ratio_not_landscape: "yatay bir imaj olmalı"
       aspect_ratio_is_not: "%{aspect_ratio} en boy oranına sahip olmalı"
       aspect_ratio_unknown: "bilinmeyen en boy oranı"
+      image_not_processable: "geçerli bir imaj değil"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -24,3 +24,4 @@ uk:
       aspect_ratio_not_landscape: "мусить бути пейзажне зображення"
       aspect_ratio_is_not: "мусить мати співвідношення сторін %{aspect_ratio}"
       aspect_ratio_unknown: "має невідоме співвідношення сторін"
+      image_not_processable: "не є допустимим зображенням"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -24,3 +24,4 @@ vi:
       aspect_ratio_not_landscape: "phải là ảnh ngang"
       aspect_ratio_is_not: "phải có tỉ lệ ảnh %{aspect_ratio}"
       aspect_ratio_unknown: "tỉ lệ ảnh không xác định"
+      image_not_processable: "không phải là ảnh"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -24,3 +24,4 @@ zh-CN:
       aspect_ratio_not_landscape: "必须是横屏图片"
       aspect_ratio_is_not: "纵横比必须是 %{aspect_ratio}"
       aspect_ratio_unknown: "未知的纵横比"
+      image_not_processable: "不是有效的图像"


### PR DESCRIPTION
Based on `en.yml`, the same translation is used for `image_not_processable` as for `image_metadata_missing`.

Fixes #204 