### PR TITLE
Fix: Fix size matcher for `has_many_attached` attachments

### DIFF
--- a/lib/active_storage_validations/matchers/size_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/size_validator_matcher.rb
@@ -92,9 +92,9 @@ module ActiveStorageValidations
           @subject.public_send(@attribute_name).attach(io: io, filename: 'test.png', content_type: 'image/pg')
           @subject.validate
           exclude_error_message = @custom_message || "file_size_not_"
-          @subject.errors.details[@attribute_name].none? do |error|
-            error[:error].to_s.include?(exclude_error_message)
-          end
+          @subject.errors.details[@attribute_name]
+            .none? { |error| error[:error].to_s.include?(exclude_error_message) }
+            .tap { @subject.attachment_changes["#{@attribute_name}"] = nil }
         end
       end
     end

--- a/test/dummy/app/models/size/portfolio.rb
+++ b/test/dummy/app/models/size/portfolio.rb
@@ -25,6 +25,8 @@ class Size::Portfolio < ApplicationRecord
   has_one_attached :proc_size_between
   has_one_attached :proc_size_with_message
 
+  has_many_attached :many_size_between
+
   validates :title, presence: true
 
   validates :size_less_than, size: { less_than: 2.kilobytes }
@@ -33,6 +35,8 @@ class Size::Portfolio < ApplicationRecord
   validates :size_greater_than_or_equal_to, size: { greater_than_or_equal_to: 7.kilobytes }
   validates :size_between, size: { between: 2.kilobytes..7.kilobytes }
   validates :size_with_message, size: { between: 2.kilobytes..7.kilobytes, message: 'is not in required file size range' }
+
+  validates :many_size_between, size: { between: 2.kilobytes..7.kilobytes }
 
   validates :proc_size_less_than, size: { less_than: -> (record) { 2.kilobytes } }
   validates :proc_size_less_than_or_equal_to, size: { less_than_or_equal_to: -> (record) { 2.kilobytes } }

--- a/test/matchers/size_validator_matcher_test.rb
+++ b/test/matchers/size_validator_matcher_test.rb
@@ -127,6 +127,43 @@ class ActiveStorageValidations::Matchers::SizeValidatorMatcher::Test < ActiveSup
     end
   end
 
+  class BetweenMatcherForManyAttachments < ActiveStorageValidations::Matchers::SizeValidatorMatcher::Test
+    test 'matches when provided with the model validation value' do
+      matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:many_size_between)
+      matcher.between 2.kilobytes..7.kilobytes
+      assert matcher.matches?(Size::Portfolio)
+    end
+
+    test 'does not match when provided a higher value than the model validation value for highest possible size' do
+      matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:many_size_between)
+      matcher.between 2.kilobytes..10.kilobytes
+      refute matcher.matches?(Size::Portfolio)
+    end
+
+    test 'does not match when provided a lower value than the model validation value for highest possible size' do
+      matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:many_size_between)
+      matcher.between 1.kilobytes..7.kilobytes
+      refute matcher.matches?(Size::Portfolio)
+    end
+
+    test 'does not match when provided a higher value than the model validation value for lowest possible size' do
+      matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:many_size_between)
+      matcher.between 5.kilobytes..7.kilobytes
+      refute matcher.matches?(Size::Portfolio)
+    end
+
+    test 'does not match when provided a lower value than the model validation value for lowest possible size' do
+      matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:many_size_between)
+      matcher.between 1.kilobytes..7.kilobytes
+      refute matcher.matches?(Size::Portfolio)
+    end
+
+    test 'does not match when provided both lowest and highest possible values different than the model validation value' do
+      matcher = ActiveStorageValidations::Matchers::SizeValidatorMatcher.new(:many_size_between)
+      matcher.between 4.kilobytes..20.kilobytes
+      refute matcher.matches?(Size::Portfolio)
+    end
+  end
 
   class WithMessageMatcher < ActiveStorageValidations::Matchers::SizeValidatorMatcher::Test
     test 'matches when provided with the model validation message' do


### PR DESCRIPTION
This PR fixes the size validator matcher for `has_many_attached` attachments.

### Details:

Currently, the matcher checks all edge cases for size validation in chain:https://github.com/igorkasyanchuk/active_storage_validations/blob/dc765443e052a04660ab4cd17ac7f05ff9715cb8/lib/active_storage_validations/matchers/size_validator_matcher.rb#L54
this works for `has_one_attached` attachments since whenever `attach` method is called, previous attachment is being replaced with a new one. https://github.com/igorkasyanchuk/active_storage_validations/blob/dc765443e052a04660ab4cd17ac7f05ff9715cb8/lib/active_storage_validations/matchers/size_validator_matcher.rb#L92
Unfortunately, this is not the case for `has_many_attached` attachments since the `attach` method adds new attachments to the list, which leads to having error validations for attachments from previous checks. To solve this issue, I added cleanup of attachments after each step.
```ruby
.tap { @subject.attachment_changes["#{@attribute_name}"] = nil }
```

It works, but if there's a better way of fixing it, please let me know, and I will try to provide a better solution.