### PR TITLE
Add install instructions to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Add to your Gemfile:
 gem "active_storage_validations"
 ```
 
+Then execute:
+
+```sh
+bundle
+```
+
+Alternatively, install yourself with:
+
+```sh
+gem install active_storage_validations
+```
+
 ## Usage
 
 For example you have a model like this and you want to add validation.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ This gems doing it for you. Just use `attached: true` or `content_type: 'image/p
 * custom error messages
 * allow procs for dynamic determination of values
 
+## Installation
+
+Add to your Gemfile:
+
+```ruby
+gem "active_storage_validations"
+```
+
 ## Usage
 
 For example you have a model like this and you want to add validation.


### PR DESCRIPTION
I didn't see the gem name or install instructions listed in the Readme and had to open the gemspec to find the gem name. This adds install instructions at the top.