### PR TITLE
Remove outdated version comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,6 @@ image_not_processable: "is not a valid image (file: %{filename})"
 Add this line to your application's Gemfile:
 
 ```ruby
-# Rails 5.2 and Rails 6
 gem 'active_storage_validations'
 
 # Optional, to use :dimension validator or :aspect_ratio validator


### PR DESCRIPTION
Hello. 
Thank you for your maintaining this repo. We've just started to use this nice validator and I noticed README was outdated. Rails 5.2 support seems ended at 1.0.0 and 6.0 was also ended at 1.1.3. I considered updating comment's version with latest 6.1 and 7 but I didn't because It's okay without it.