### PR TITLE
Accept content types like "image/*"

### DIFF
--- a/lib/active_storage_validations/content_type_validator.rb
+++ b/lib/active_storage_validations/content_type_validator.rb
@@ -60,7 +60,9 @@ module ActiveStorageValidations
     def is_valid?(file, types)
       file_type = content_type(file)
       types.any? do |type|
-        type == file_type || (type.is_a?(Regexp) && type.match?(file_type.to_s))
+        type == file_type ||
+          (type.is_a?(Regexp) && type.match?(file_type.to_s)) ||
+          (type.is_a?(String) && type.end_with?("/*") && file_type.start_with?(type[0..-2]))
       end
     end
 


### PR DESCRIPTION
I would like to be able to use content type validations like "image/*".

Currently, this is only supported with a regex (/\Aimage\/*\z/) which is kind of ugly and unnecessarily complicated IMO, but also has the downside that the value cannot directly be used as [the "accept" attribute on a HTML input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept), which is what I'm doing in my app.

It turns out that accepting strings like "image/*" was a relatively small change.

If this is an acceptable change to be merged, I am happy to add some tests for it as well! 😸 