### PR TITLE
has_many_attached validate_size_of fix

### DIFF
--- a/lib/active_storage_validations/matchers/size_validator_matcher.rb
+++ b/lib/active_storage_validations/matchers/size_validator_matcher.rb
@@ -139,7 +139,11 @@ module ActiveStorageValidations
       end
 
       def attach_file
-        @subject.public_send(@attribute_name).attach(dummy_file)
+        @subject.public_send("#{@attribute_name}=", attachable)
+      end
+
+      def attachable
+        @subject.public_send(@attribute_name).class == ActiveStorage::Attached::Many ? [dummy_file] : dummy_file
       end
 
       def dummy_file

--- a/test/dummy/app/models/size/matcher.rb
+++ b/test/dummy/app/models/size/matcher.rb
@@ -66,7 +66,7 @@ class Size::Matcher < ApplicationRecord
   has_one_attached :less_than_or_equal_to_with_message
   has_one_attached :greater_than_with_message
   has_one_attached :greater_than_or_equal_to_with_message
-  has_one_attached :between_with_message
+  has_many_attached :between_with_message
   validates :less_than_with_message, size: { less_than: 2.kilobytes, message: 'File is too big.' }
   validates :less_than_or_equal_to_with_message, size: { less_than_or_equal_to: 2.kilobytes, message: 'File is too big.' }
   validates :greater_than_with_message, size: { greater_than: 7.kilobytes, message: 'File is too small.' }


### PR DESCRIPTION
`ActiveStorageValidations::Matchers::SizeValidatorMatcher#attach_file` is currently using `attach`, which adds a new attachment instead of replacing the existing one when the relation type is `has_many_attached`. This causes a false negative because the validation in `higher_than_min?` fails due to the invalid attachment that was previously created by `not_lower_than_min?`.

The proposed solution is to use `"#{@attribute_name}="`, which will clear all previously attached files.