### PR TITLE
Remove dead code for Rails 5.x, 6.x, and < 6.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,18 +455,6 @@ Tips:
 - To focus a specific file, use the TEST option provided by minitest, e.g. to only run size_validator_test.rb file you will execute the following command: `bundle exec rake test TEST=test/validators/size_validator_test.rb`
 
 
-## Known issues
-
-- There is an issue in Rails which it possible to get if you have added a validation and generating for example an image preview of attachments. It can be fixed with this:
-
-```erb
-  <% if @user.avatar.attached? && @user.avatar.attachment.blob.present? && @user.avatar.attachment.blob.persisted? %>
-    <%= image_tag @user.avatar %>
-  <% end %>
-```
-
-This is a Rails issue, and is fixed in Rails 6.
-
 ## Contributing
 
 You are welcome to contribute.

--- a/lib/active_storage_validations/aspect_ratio_validator.rb
+++ b/lib/active_storage_validations/aspect_ratio_validator.rb
@@ -28,36 +28,18 @@ module ActiveStorageValidations
       ensure_aspect_ratio_validity
     end
 
-    if Rails.gem_version >= Gem::Version.new('6.0.0')
-      def validate_each(record, attribute, _value)
-        return true unless record.send(attribute).attached?
+    def validate_each(record, attribute, _value)
+      return true unless record.send(attribute).attached?
 
-        changes = record.attachment_changes[attribute.to_s]
-        return true if changes.blank?
+      changes = record.attachment_changes[attribute.to_s]
+      return true if changes.blank?
 
-        files = Array.wrap(changes.is_a?(ActiveStorage::Attached::Changes::CreateMany) ? changes.attachables : changes.attachable)
+      files = Array.wrap(changes.is_a?(ActiveStorage::Attached::Changes::CreateMany) ? changes.attachables : changes.attachable)
 
-        files.each do |file|
-          metadata = Metadata.new(file).metadata
-          next if is_valid?(record, attribute, file, metadata)
-          break
-        end
-      end
-    else
-      # Rails 5
-      def validate_each(record, attribute, _value)
-        return true unless record.send(attribute).attached?
-
-        files = Array.wrap(record.send(attribute))
-
-        files.each do |file|
-          # Analyze file first if not analyzed to get all required metadata.
-          file.analyze; file.reload unless file.analyzed?
-          metadata = file.metadata
-
-          next if is_valid?(record, attribute, file, metadata)
-          break
-        end
+      files.each do |file|
+        metadata = Metadata.new(file).metadata
+        next if is_valid?(record, attribute, file, metadata)
+        break
       end
     end
 

--- a/lib/active_storage_validations/content_type_spoof_detector.rb
+++ b/lib/active_storage_validations/content_type_spoof_detector.rb
@@ -49,11 +49,7 @@ module ActiveStorageValidations
       when ActionDispatch::Http::UploadedFile
         attachable.read
       when String
-        blob = if Rails.gem_version < Gem::Version.new('6.1.0')
-                ActiveStorage::Blob.find_signed(attachable)
-              else
-                ActiveStorage::Blob.find_signed!(attachable)
-              end
+        blob = ActiveStorage::Blob.find_signed!(attachable)
         blob.download
       when ActiveStorage::Blob
         attachable.download
@@ -72,11 +68,7 @@ module ActiveStorageValidations
         end.read
       elsif attachables.all? { |attachable| attachable.is_a?(String) }
         # It's only possible to pass one String as attachable (not an array of String)
-        blob = if Rails.gem_version < Gem::Version.new('6.1.0')
-                 ActiveStorage::Blob.find_signed(attachables.first)
-               else
-                 ActiveStorage::Blob.find_signed!(attachables.first)
-               end
+        blob = ActiveStorage::Blob.find_signed!(attachables.first)
         blob.download
       elsif attachables.all? { |attachable| attachable.is_a?(ActiveStorage::Blob) }
         attachables.find { |blob| blob == @file.blob }.download
@@ -132,14 +124,7 @@ module ActiveStorageValidations
     end
 
     def parent_content_types(content_type)
-      if Rails.gem_version < Gem::Version.new('6.1.4')
-        []
-      else
-        # Marcel parent feature is only available starting from marcel v1.0.3
-        # Rails >= 6.1.4 relies on marcel ~> 1.0
-        # Rails < 6.1.4 relies on marcel ~> 0.3.1
-        Marcel::TYPE_PARENTS[content_type] || []
-      end
+      Marcel::TYPE_PARENTS[content_type] || []
     end
   end
 end

--- a/lib/active_storage_validations/dimension_validator.rb
+++ b/lib/active_storage_validations/dimension_validator.rb
@@ -54,36 +54,19 @@ module ActiveStorageValidations
     end
 
 
-    if Rails.gem_version >= Gem::Version.new('6.0.0')
-      def validate_each(record, attribute, _value)
-        return true unless record.send(attribute).attached?
+    def validate_each(record, attribute, _value)
+      return true unless record.send(attribute).attached?
 
-        changes = record.attachment_changes[attribute.to_s]
-        return true if changes.blank?
+      changes = record.attachment_changes[attribute.to_s]
+      return true if changes.blank?
 
-        files = Array.wrap(changes.is_a?(ActiveStorage::Attached::Changes::CreateMany) ? changes.attachables : changes.attachable)
-        files.each do |file|
-          metadata = Metadata.new(file).metadata
-          next if is_valid?(record, attribute, file, metadata)
-          break
-        end
-      end
-    else
-      # Rails 5
-      def validate_each(record, attribute, _value)
-        return true unless record.send(attribute).attached?
-
-        files = Array.wrap(record.send(attribute))
-        files.each do |file|
-          # Analyze file first if not analyzed to get all required metadata.
-          file.analyze; file.reload unless file.analyzed?
-          metadata = file.metadata rescue {}
-          next if is_valid?(record, attribute, file, metadata)
-          break
-        end
+      files = Array.wrap(changes.is_a?(ActiveStorage::Attached::Changes::CreateMany) ? changes.attachables : changes.attachable)
+      files.each do |file|
+        metadata = Metadata.new(file).metadata
+        next if is_valid?(record, attribute, file, metadata)
+        break
       end
     end
-
 
     def is_valid?(record, attribute, file, metadata)
       flat_options = process_options(record)

--- a/lib/active_storage_validations/marcel_extensor.rb
+++ b/lib/active_storage_validations/marcel_extensor.rb
@@ -1,10 +1,5 @@
-if Rails.gem_version >= Gem::Version.new('6.1.4')
-  # Marcel parent feature is only available starting from marcel v1.0.3
-  # Rails >= 6.1.4 relies on marcel ~> 1.0
-  # Rails < 6.1.4 relies on marcel ~> 0.3.1
-  Marcel::MimeType.extend "application/x-rar-compressed", parents: %(application/x-rar)
-  Marcel::MimeType.extend "audio/x-hx-aac-adts", parents: %(audio/x-aac)
-  Marcel::MimeType.extend "audio/x-m4a", parents: %(audio/mp4)
-  Marcel::MimeType.extend "text/xml", parents: %(application/xml) # alias
-  Marcel::MimeType.extend "video/theora", parents: %(video/ogg)
-end
+Marcel::MimeType.extend "application/x-rar-compressed", parents: %(application/x-rar)
+Marcel::MimeType.extend "audio/x-hx-aac-adts", parents: %(audio/x-aac)
+Marcel::MimeType.extend "audio/x-m4a", parents: %(audio/mp4)
+Marcel::MimeType.extend "text/xml", parents: %(application/xml) # alias
+Marcel::MimeType.extend "video/theora", parents: %(video/ogg)

--- a/lib/active_storage_validations/matchers.rb
+++ b/lib/active_storage_validations/matchers.rb
@@ -25,21 +25,9 @@ module ActiveStorageValidations
     end
 
     def self.mock_metadata(attachment, width, height)
-      if Rails.gem_version >= Gem::Version.new('6.0.0')
-        # Mock the Metadata class for rails 6
-        mock = Struct.new(:metadata).new({ width: width, height: height })
-        stub_method(ActiveStorageValidations::Metadata, :new, mock) do
-          yield
-        end
-      else
-        # Stub the metadata analysis for rails 5
-        stub_method(attachment, :analyze, true) do
-          stub_method(attachment, :analyzed?, true) do
-            stub_method(attachment, :metadata, { width: width, height: height }) do
-              yield
-            end
-          end
-        end
+      mock = Struct.new(:metadata).new({ width: width, height: height })
+      stub_method(ActiveStorageValidations::Metadata, :new, mock) do
+        yield
       end
     end
   end

--- a/lib/active_storage_validations/metadata.rb
+++ b/lib/active_storage_validations/metadata.rb
@@ -68,11 +68,7 @@ module ActiveStorageValidations
       if is_string || file.is_a?(ActiveStorage::Blob)
         blob =
           if is_string
-            if Rails.gem_version < Gem::Version.new('6.1.0')
-              ActiveStorage::Blob.find_signed(file)
-            else
-              ActiveStorage::Blob.find_signed!(file)
-            end
+            ActiveStorage::Blob.find_signed!(file)
           else
             file
           end

--- a/lib/active_storage_validations/processable_image_validator.rb
+++ b/lib/active_storage_validations/processable_image_validator.rb
@@ -14,34 +14,18 @@ module ActiveStorageValidations
       image_not_processable
     ].freeze
 
-    if Rails.gem_version >= Gem::Version.new('6.0.0')
-      def validate_each(record, attribute, _value)
-        return true unless record.send(attribute).attached?
+    def validate_each(record, attribute, _value)
+      return true unless record.send(attribute).attached?
 
-        changes = record.attachment_changes[attribute.to_s]
-        return true if changes.blank?
+      changes = record.attachment_changes[attribute.to_s]
+      return true if changes.blank?
 
-        files = Array.wrap(changes.is_a?(ActiveStorage::Attached::Changes::CreateMany) ? changes.attachables : changes.attachable)
+      files = Array.wrap(changes.is_a?(ActiveStorage::Attached::Changes::CreateMany) ? changes.attachables : changes.attachable)
 
-        files.each do |file|
-          if !Metadata.new(file).valid?
-            errors_options = initialize_error_options(options, file)
-            add_error(record, attribute, ERROR_TYPES.first , **errors_options) unless Metadata.new(file).valid?
-          end
-        end
-      end
-    else
-      # Rails 5
-      def validate_each(record, attribute, _value)
-        return true unless record.send(attribute).attached?
-
-        files = Array.wrap(record.send(attribute))
-
-        files.each do |file|
-          if !Metadata.new(file).valid?
-            errors_options = initialize_error_options(options, file)
-            add_error(record, attribute, ERROR_TYPES.first , **errors_options) unless Metadata.new(file).valid?
-          end
+      files.each do |file|
+        if !Metadata.new(file).valid?
+          errors_options = initialize_error_options(options, file)
+          add_error(record, attribute, ERROR_TYPES.first , **errors_options) unless Metadata.new(file).valid?
         end
       end
     end

--- a/test/active_storage_validations_test.rb
+++ b/test/active_storage_validations_test.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # Run tests using:
-# BUNDLE_GEMFILE=gemfiles/rails_5_2.gemfile bundle exec rake test
-# BUNDLE_GEMFILE=gemfiles/rails_6_0.gemfile bundle exec rake test
+# BUNDLE_GEMFILE=gemfiles/rails_6_1_4.gemfile bundle exec rake test
+# BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake test
 
 require 'test_helper'
 
@@ -184,7 +184,7 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     assert_equal e.errors.full_messages, ["Documents total number is out of range"]
   end
 
-  test 'validates number of files for Rails 6' do
+  test 'validates number of files' do
     la = LimitAttachment.create(name: 'klingon')
     la.files.attach([pdf_file, pdf_file, pdf_file, pdf_file, pdf_file, pdf_file])
     la.proc_files.attach([pdf_file, pdf_file, pdf_file, pdf_file, pdf_file, pdf_file])
@@ -194,26 +194,10 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     assert_equal 6, la.files.count
     assert_equal 6, la.proc_files.count
 
-    if Rails.gem_version < Gem::Version.new('6.0.0')
-      assert_equal 6, la.files_blobs.count
-      assert_equal 6, la.proc_files_blobs.count
-    else
-      assert_equal 0, la.files_blobs.count
-      assert_equal 0, la.proc_files_blobs.count
-    end
+    assert_equal 0, la.files_blobs.count
+    assert_equal 0, la.proc_files_blobs.count
 
     assert_equal ['Files total number is out of range', 'Proc files total number is out of range'], la.errors.full_messages
-
-    if Rails.gem_version < Gem::Version.new('6.0.0')
-      la.files.first.purge
-      la.proc_files.first.purge
-      la.files.first.purge
-      la.proc_files.first.purge
-      la.files.first.purge
-      la.proc_files.first.purge
-      la.files.first.purge
-      la.proc_files.first.purge
-    end
 
     assert !la.valid?
     assert_equal ['Files total number is out of range', 'Proc files total number is out of range'], la.errors.full_messages
@@ -373,12 +357,7 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
 
     assert_nil e.dimension_min.attachment
     assert_nil e.proc_dimension_min.attachment
-    blob =
-      if Rails.gem_version >= Gem::Version.new('6.1.0')
-        ActiveStorage::Blob.create_and_upload!(**image_800x600_file)
-      else
-        ActiveStorage::Blob.create_after_upload!(**image_800x600_file)
-      end
+    blob = ActiveStorage::Blob.create_and_upload!(**image_800x600_file)
     e.dimension_min = blob.signed_id
     e.proc_dimension_min = blob.signed_id
     e.save!

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -21,17 +21,13 @@ ActiveRecord::Schema.define do
     t.datetime :created_at, null: false
     t.index %i[key], name: :index_active_storage_blobs_on_key, unique: true
 
-    if Rails.gem_version >= Gem::Version.new('6.1.0')
-      t.string :service_name, null: false
-    end
+    t.string :service_name, null: false
   end
 
-  if Rails.gem_version >= Gem::Version.new('6.1.0')
-    create_table :active_storage_variant_records, force: :cascade do |t|
-      t.bigint :blob_id, null: false
-      t.string :variation_digest, null: false
-      t.index %i[blob_id variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
-    end
+  create_table :active_storage_variant_records, force: :cascade do |t|
+    t.bigint :blob_id, null: false
+    t.string :variation_digest, null: false
+    t.index %i[blob_id variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
   end
 
   %i(

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ require 'combustion'
 Combustion.path = 'test/dummy'
 Combustion.initialize! :active_record, :active_storage, :active_job do
   config.active_storage.variant_processor = ENV['IMAGE_PROCESSOR']&.to_sym
-  config.active_job.queue_adapter = :inline if Rails.gem_version >= Gem::Version.new('6.0.0')
+  config.active_job.queue_adapter = :inline
 end
 
 # Load other test helpers

--- a/test/validators/support/validator_helpers.rb
+++ b/test/validators/support/validator_helpers.rb
@@ -10,16 +10,10 @@ module ValidatorHelpers
   def is_expected_to_have_error_options(error_options, **kwargs)
     subject.valid?(kwargs[:context])
 
-    # Rails 6.1.0 changes the form of ActiveModel’s errors collection
-    # https://github.com/rails/rails/blob/6-1-stable/activemodel/CHANGELOG.md#rails-610-december-09-2020
-    validator_error_options = if Rails.gem_version >= Gem::Version.new('6.1.0')
+    validator_error_options =
       subject.errors.find do |error|
         error.options[:validator_type] == kwargs[:validator] || validator_sym
       end.options
-    else
-      # For errors before Rails 6.1.0 we do not have error options
-      return true
-    end
 
     assert(
       error_options.all? do |key, _value|
@@ -32,16 +26,10 @@ module ValidatorHelpers
   def is_expected_to_have_error_message(message_key, **kwargs)
     subject.valid?(kwargs[:context])
 
-    # Rails 6.1.0 changes the form of ActiveModel’s errors collection
-    # https://github.com/rails/rails/blob/6-1-stable/activemodel/CHANGELOG.md#rails-610-december-09-2020
-    validator_error_message = if Rails.gem_version >= Gem::Version.new('6.1.0')
+    validator_error_message =
       subject.errors.find do |error|
         error.options[:validator_type] == kwargs[:validator] || validator_sym
       end.message
-    else
-      # For errors before Rails 6.1.0 we do not have error options
-      return true
-    end
 
     message = kwargs[:error_options][:custom_message] || I18n.t("errors.messages.#{message_key}", **kwargs[:error_options])
 


### PR DESCRIPTION
PR igorkasyanchuk#256 updated the minimum required version of Rails subcomponents to
6.1.4.

However, it also included conditionals specific to version 6.1.4.

This code is unnecessary as the library does not support versions of
Rails below 6.1.4.

---

Please review with "hide whitespace" option enabled

![image](https://github.com/user-attachments/assets/8b804e68-ff5b-4f20-9f58-549088d8127c)
