### PR TITLE
Support file extensions in uppercase

### DIFF
--- a/lib/active_storage_validations/content_type_validator.rb
+++ b/lib/active_storage_validations/content_type_validator.rb
@@ -67,7 +67,7 @@ module ActiveStorageValidations
 
       extension = @attachable_filename.split('.').last
       possible_extensions = Marcel::TYPE_EXTS[@attachable_content_type]
-      return true if possible_extensions && extension.in?(possible_extensions)
+      return true if possible_extensions && extension.downcase.in?(possible_extensions)
 
       errors_options = initialize_and_populate_error_options(options, attachable)
       add_error(record, attribute, ERROR_TYPES.first, **errors_options)

--- a/test/dummy/app/models/content_type/validator/check.rb
+++ b/test/dummy/app/models/content_type/validator/check.rb
@@ -27,6 +27,8 @@ class ContentType::Validator::Check < ApplicationRecord
   validates :extension_two_extensions_docx, content_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
   has_one_attached :extension_two_extensions_pdf
   validates :extension_two_extensions_pdf, content_type: 'application/pdf'
+  has_one_attached :pdf_file
+  validates :pdf_file, content_type: 'application/pdf'
 
   %w(symbol string regex).each do |type|
     has_one_attached :"with_#{type}"

--- a/test/dummy/app/models/content_type/validator/check.rb
+++ b/test/dummy/app/models/content_type/validator/check.rb
@@ -27,8 +27,10 @@ class ContentType::Validator::Check < ApplicationRecord
   validates :extension_two_extensions_docx, content_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
   has_one_attached :extension_two_extensions_pdf
   validates :extension_two_extensions_pdf, content_type: 'application/pdf'
-  has_one_attached :pdf_file
-  validates :pdf_file, content_type: 'application/pdf'
+  has_one_attached :extension_upcase_extension
+  validates :extension_upcase_extension, content_type: 'application/pdf'
+  has_one_attached :extension_missing_extension
+  validates :extension_missing_extension, content_type: 'application/pdf'
 
   %w(symbol string regex).each do |type|
     has_one_attached :"with_#{type}"

--- a/test/validators/content_type_validator_test.rb
+++ b/test/validators/content_type_validator_test.rb
@@ -130,7 +130,7 @@ describe ActiveStorageValidations::ContentTypeValidator do
       describe "when the extension is in uppercase" do
         subject { model.public_send(attribute).attach(pdf_file_with_extension_in_uppercase) and model }
 
-        let(:attribute) { :pdf_file }
+        let(:attribute) { :extension_upcase_extension }
         let(:pdf_file_with_extension_in_uppercase) do
           pdf_file.tap do |file|
             file[:filename][".pdf"] = ".PDF"
@@ -143,7 +143,7 @@ describe ActiveStorageValidations::ContentTypeValidator do
       describe "when the extension is missing" do
         subject { model.public_send(attribute).attach(pdf_file_without_extension) and model }
 
-        let(:attribute) { :pdf_file }
+        let(:attribute) { :extension_missing_extension }
         let(:pdf_file_without_extension) do
           pdf_file.tap do |file|
             file[:filename][".pdf"] = ""

--- a/test/validators/content_type_validator_test.rb
+++ b/test/validators/content_type_validator_test.rb
@@ -126,6 +126,41 @@ describe ActiveStorageValidations::ContentTypeValidator do
           it { is_expected_to_be_valid }
         end
       end
+
+      describe "when the extension is in uppercase" do
+        subject { model.public_send(attribute).attach(pdf_file_with_extension_in_uppercase) and model }
+
+        let(:attribute) { :pdf_file }
+        let(:pdf_file_with_extension_in_uppercase) do
+          pdf_file.tap do |file|
+            file[:filename][".pdf"] = ".PDF"
+          end
+        end
+
+        it { is_expected_to_be_valid }
+      end
+
+      describe "when the extension is missing" do
+        subject { model.public_send(attribute).attach(pdf_file_without_extension) and model }
+
+        let(:attribute) { :pdf_file }
+        let(:pdf_file_without_extension) do
+          pdf_file.tap do |file|
+            file[:filename][".pdf"] = ""
+          end
+        end
+        let(:error_options) do
+          {
+            authorized_types: "PDF",
+            content_type: pdf_file_without_extension[:content_type],
+            filename: pdf_file_without_extension[:filename]
+          }
+        end
+
+        it { is_expected_not_to_be_valid }
+        it { is_expected_to_have_error_message("content_type_invalid", error_options: error_options) }
+        it { is_expected_to_have_error_options(error_options) }
+      end
     end
 
     describe ":with" do


### PR DESCRIPTION
Since version 1.3.1 (fa64570), the extension of an attachment is validated against its content type. However, when the extension is not in lowercase, validation fails.

This commit fixes the issue by downcasing the attachment's extension before checking it against possible extensions for the content type.