### PR TITLE
Allow multiple aspect ratios

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ en:
       aspect_ratio_not_landscape: "must be a landscape image"
       aspect_ratio_is_not: "must have an aspect ratio of %{aspect_ratio}"
       image_not_processable: "is not a valid image"
+      aspect_ratio_invalid: "has invalid aspect ratio"
 ```
 
 In several cases, Active Storage Validations provides variables to help you customize messages:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -30,3 +30,4 @@ da:
       aspect_ratio_not_landscape: "skal være et landskabsbillede"
       aspect_ratio_is_not: "skal have et størrelsesforhold på %{aspect_ratio}"
       image_not_processable: "er ikke et gyldigt billede"
+      aspect_ratio_invalid: "har et ugyldigt billedformat"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -30,3 +30,4 @@ de:
       aspect_ratio_not_landscape: "muss Querformat sein"
       aspect_ratio_is_not: "muss ein Bildseitenverhältnis von %{aspect_ratio} haben"
       image_not_processable: "ist kein gültiges Bild"
+      aspect_ratio_invalid: "hat ein ungültiges Seitenverhältnis"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,4 @@ en:
       aspect_ratio_not_landscape: "must be a landscape image"
       aspect_ratio_is_not: "must have an aspect ratio of %{aspect_ratio}"
       image_not_processable: "is not a valid image"
-      aspect_ratio_invalid: "has invalid aspect ratio"
+      aspect_ratio_invalid: "has an invalid aspect ratio"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,3 +30,4 @@ en:
       aspect_ratio_not_landscape: "must be a landscape image"
       aspect_ratio_is_not: "must have an aspect ratio of %{aspect_ratio}"
       image_not_processable: "is not a valid image"
+      aspect_ratio_invalid: "has invalid aspect ratio"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -30,3 +30,4 @@ es:
       aspect_ratio_not_landscape: "debe ser una imagen apaisada"
       aspect_ratio_is_not: "debe tener una relación de aspecto de %{aspect_ratio}"
       image_not_processable: "no es una imagen válida"
+      aspect_ratio_invalid: "tiene una relación de aspecto no válida"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -30,3 +30,4 @@ fr:
       aspect_ratio_not_landscape: "doit être une image en format paysage"
       aspect_ratio_is_not: "doit avoir un rapport hauteur / largeur de %{aspect_ratio}"
       image_not_processable: "n'est pas une image valide"
+      aspect_ratio_invalid: "a un rapport hauteur / largeur invalide"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -30,3 +30,4 @@ it:
       aspect_ratio_not_landscape: "l’orientamento dell’immagine deve essere orizzontale"
       aspect_ratio_is_not: "deve avere un rapporto altezza / larghezza di %{aspect_ratio}"
       image_not_processable: "non è un'immagine valida"
+      aspect_ratio_invalid: "ha un rapporto di aspetto non valido"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -30,4 +30,4 @@ it:
       aspect_ratio_not_landscape: "l’orientamento dell’immagine deve essere orizzontale"
       aspect_ratio_is_not: "deve avere un rapporto altezza / larghezza di %{aspect_ratio}"
       image_not_processable: "non è un'immagine valida"
-      aspect_ratio_invalid: "ha un rapporto di aspetto non valido"
+      aspect_ratio_invalid: "ha proporzioni non valide"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -30,3 +30,4 @@ ja:
       aspect_ratio_not_landscape: "は横長にしてください"
       aspect_ratio_is_not: "のアスペクト比は %{aspect_ratio} にしてください"
       image_not_processable: "は不正な画像です"
+      aspect_ratio_invalid: "アスペクト比が無効です"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -30,3 +30,4 @@ nl:
       aspect_ratio_not_landscape: "moet een liggende afbeelding zijn"
       aspect_ratio_is_not: "moet een beeldverhouding hebben van %{aspect_ratio}"
       image_not_processable: "is geen geldige afbeelding"
+      aspect_ratio_invalid: "heeft een ongeldige beeldverhouding"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -30,3 +30,4 @@ pl:
       aspect_ratio_not_landscape: "musi mieć proporcje pejzażu"
       aspect_ratio_is_not: "musi mieć proporcje %{aspect_ratio}"
       image_not_processable: "nie jest prawidłowym obrazem"
+      aspect_ratio_invalid: "ma nieprawidłowy współczynnik proporcji"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -30,4 +30,4 @@ pt-BR:
       aspect_ratio_not_landscape: "não está no formato paisagem"
       aspect_ratio_is_not: "não contém uma proporção de %{aspect_ratio}"
       image_not_processable: "não é uma imagem válida"
-      aspect_ratio_invalid: "tem proporção de aspecto inválida"
+      aspect_ratio_invalid: "tem uma proporção de aspecto inválida"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -30,3 +30,4 @@ pt-BR:
       aspect_ratio_not_landscape: "não está no formato paisagem"
       aspect_ratio_is_not: "não contém uma proporção de %{aspect_ratio}"
       image_not_processable: "não é uma imagem válida"
+      aspect_ratio_invalid: "tem proporção de aspecto inválida"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -30,3 +30,4 @@ ru:
       aspect_ratio_not_landscape: "должно быть пейзажное изображение"
       aspect_ratio_is_not: "должен иметь соотношение сторон %{aspect_ratio}"
       image_not_processable: "не является допустимым изображением"
+      aspect_ratio_invalid: "имеет недопустимое соотношение сторон"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -30,3 +30,4 @@ sv:
       aspect_ratio_not_landscape: "måste vara en landskapsorienterad bild"
       aspect_ratio_is_not: "måste ha en följande aspect ratio  %{aspect_ratio}"
       image_not_processable: "är inte en giltig bild"
+      aspect_ratio_invalid: "har ogiltigt bildförhållande"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -30,4 +30,4 @@ sv:
       aspect_ratio_not_landscape: "måste vara en landskapsorienterad bild"
       aspect_ratio_is_not: "måste ha en följande aspect ratio  %{aspect_ratio}"
       image_not_processable: "är inte en giltig bild"
-      aspect_ratio_invalid: "har ogiltigt bildförhållande"
+      aspect_ratio_invalid: "har ett ogiltigt bildförhållande"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -30,3 +30,4 @@ tr:
       aspect_ratio_not_landscape: "yatay bir imaj olmalı"
       aspect_ratio_is_not: "%{aspect_ratio} en boy oranına sahip olmalı"
       image_not_processable: "geçerli bir imaj değil"
+      aspect_ratio_invalid: "geçersiz en boy oranına sahip"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -30,4 +30,4 @@ tr:
       aspect_ratio_not_landscape: "yatay bir imaj olmalı"
       aspect_ratio_is_not: "%{aspect_ratio} en boy oranına sahip olmalı"
       image_not_processable: "geçerli bir imaj değil"
-      aspect_ratio_invalid: "geçersiz en boy oranına sahip"
+      aspect_ratio_invalid: "geçersiz bir en boy oranına sahip"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -30,3 +30,4 @@ uk:
       aspect_ratio_not_landscape: "мусить бути пейзажне зображення"
       aspect_ratio_is_not: "мусить мати співвідношення сторін %{aspect_ratio}"
       image_not_processable: "не є допустимим зображенням"
+      aspect_ratio_invalid: "має недійсне співвідношення сторін"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -30,3 +30,4 @@ vi:
       aspect_ratio_not_landscape: "phải là ảnh ngang"
       aspect_ratio_is_not: "phải có tỉ lệ ảnh %{aspect_ratio}"
       image_not_processable: "không phải là ảnh"
+      aspect_ratio_invalid: "có tỷ lệ khung hình không hợp lệ"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -30,3 +30,4 @@ zh-CN:
       aspect_ratio_not_landscape: "必须是横屏图片"
       aspect_ratio_is_not: "纵横比必须是 %{aspect_ratio}"
       image_not_processable: "不是有效的图像"
+      aspect_ratio_invalid: "宽高比无效"

--- a/lib/active_storage_validations/aspect_ratio_validator.rb
+++ b/lib/active_storage_validations/aspect_ratio_validator.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'shared/asv_active_storageable'
-require_relative 'shared/asv_analyzable'
 require_relative 'shared/asv_attachable'
 require_relative 'shared/asv_errorable'
 require_relative 'shared/asv_optionable'
@@ -10,23 +9,23 @@ require_relative 'shared/asv_symbolizable'
 module ActiveStorageValidations
   class AspectRatioValidator < ActiveModel::EachValidator # :nodoc
     include ASVActiveStorageable
-    include ASVAnalyzable
     include ASVAttachable
     include ASVErrorable
     include ASVOptionable
     include ASVSymbolizable
 
-    AVAILABLE_CHECKS = %i[with].freeze
+    AVAILABLE_CHECKS = %i[with in].freeze
     NAMED_ASPECT_RATIOS = %i[square portrait landscape].freeze
     ASPECT_RATIO_REGEX = /is_([1-9]\d*)_([1-9]\d*)/.freeze
+    PRECISION = 3
     ERROR_TYPES = %i[
+      aspect_ratio_invalid
       image_metadata_missing
       aspect_ratio_not_square
       aspect_ratio_not_portrait
       aspect_ratio_not_landscape
       aspect_ratio_is_not
     ].freeze
-    PRECISION = 3.freeze
 
     def check_validity!
       ensure_at_least_one_validator_option
@@ -46,75 +45,100 @@ module ActiveStorageValidations
 
       return if image_metadata_missing?(record, attribute, attachable, flat_options, metadata)
 
-      case flat_options[:with]
-      when :square then validate_square_aspect_ratio(record, attribute, attachable, flat_options, metadata)
-      when :portrait then validate_portrait_aspect_ratio(record, attribute, attachable, flat_options, metadata)
-      when :landscape then validate_landscape_aspect_ratio(record, attribute, attachable, flat_options, metadata)
-      when ASPECT_RATIO_REGEX then validate_regex_aspect_ratio(record, attribute, attachable, flat_options, metadata)
+      aspect_ratios = aspect_ratios(flat_options).compact
+      errors = aspect_ratios.map do |aspect_ratio|
+        aspect_ratio_error(aspect_ratio, metadata)
+      end.compact
+
+      return true if errors.length != aspect_ratios.length
+
+      error = aspect_ratios.length == 1 ? errors.first : :aspect_ratio_invalid
+
+      errors_options = initialize_error_options(options, attachable)
+      errors_options[:aspect_ratio] = string_aspect_ratios(flat_options)
+      add_error(record, attribute, error, **errors_options)
+      false
+    end
+
+    def aspect_ratio_error(aspect_ratio, metadata)
+      case aspect_ratio
+      when :square then validate_square_aspect_ratio(metadata)
+      when :portrait then validate_portrait_aspect_ratio(metadata)
+      when :landscape then validate_landscape_aspect_ratio(metadata)
+      when ASPECT_RATIO_REGEX then valid_regex_aspect_ratio?(aspect_ratio, metadata)
       end
     end
 
     def image_metadata_missing?(record, attribute, attachable, flat_options, metadata)
-      return false if metadata.present? && metadata[:width].to_i > 0 && metadata[:height].to_i > 0
+      return false if metadata[:width].to_i > 0 && metadata[:height].to_i > 0
 
       errors_options = initialize_error_options(options, attachable)
-      errors_options[:aspect_ratio] = flat_options[:with]
+      errors_options[:aspect_ratio] = string_aspect_ratios(flat_options)
       add_error(record, attribute, :image_metadata_missing, **errors_options)
       true
     end
 
-    def validate_square_aspect_ratio(record, attribute, attachable, flat_options, metadata)
-      return if metadata[:width] == metadata[:height]
-
-      errors_options = initialize_error_options(options, attachable)
-      errors_options[:aspect_ratio] = flat_options[:with]
-      add_error(record, attribute, :aspect_ratio_not_square, **errors_options)
+    def validate_square_aspect_ratio(metadata)
+      :aspect_ratio_not_square unless metadata[:width] == metadata[:height]
     end
 
-    def validate_portrait_aspect_ratio(record, attribute, attachable, flat_options, metadata)
-      return if metadata[:width] < metadata[:height]
-
-      errors_options = initialize_error_options(options, attachable)
-      errors_options[:aspect_ratio] = flat_options[:with]
-      add_error(record, attribute, :aspect_ratio_not_portrait, **errors_options)
+    def validate_portrait_aspect_ratio(metadata)
+      :aspect_ratio_not_portrait unless metadata[:width] < metadata[:height]
     end
 
-    def validate_landscape_aspect_ratio(record, attribute, attachable, flat_options, metadata)
-      return if metadata[:width] > metadata[:height]
-
-      errors_options = initialize_error_options(options, attachable)
-      errors_options[:aspect_ratio] = flat_options[:with]
-      add_error(record, attribute, :aspect_ratio_not_landscape, **errors_options)
+    def validate_landscape_aspect_ratio(metadata)
+      :aspect_ratio_not_landscape unless metadata[:width] > metadata[:height]
     end
 
-    def validate_regex_aspect_ratio(record, attribute, attachable, flat_options, metadata)
-      flat_options[:with] =~ ASPECT_RATIO_REGEX
-      x = $1.to_i
-      y = $2.to_i
+    def valid_regex_aspect_ratio?(aspect_ratio, metadata)
+      aspect_ratio =~ ASPECT_RATIO_REGEX
+      x = ::Regexp.last_match(1).to_i
+      y = ::Regexp.last_match(2).to_i
 
-      return if x > 0 && y > 0 && (x.to_f / y).round(PRECISION) == (metadata[:width].to_f / metadata[:height]).round(PRECISION)
-
-      errors_options = initialize_error_options(options, attachable)
-      errors_options[:aspect_ratio] = "#{x}:#{y}"
-      add_error(record, attribute, :aspect_ratio_is_not, **errors_options)
+      unless x > 0 && y > 0 && (x.to_f / y).round(PRECISION) == (metadata[:width].to_f / metadata[:height]).round(PRECISION)
+        :aspect_ratio_is_not
+      end
     end
 
     def ensure_at_least_one_validator_option
-      unless AVAILABLE_CHECKS.any? { |argument| options.key?(argument) }
-        raise ArgumentError, 'You must pass :with to the validator'
-      end
+      return if AVAILABLE_CHECKS.any? { |argument| options.key?(argument) }
+
+      raise ArgumentError, 'You must pass either :with or :in to the validator'
     end
 
     def ensure_aspect_ratio_validity
-      return true if options[:with]&.is_a?(Proc)
+      return true if options[:with]&.is_a?(Proc) || options[:in]&.is_a?(Proc)
 
-      unless NAMED_ASPECT_RATIOS.include?(options[:with]) || options[:with] =~ ASPECT_RATIO_REGEX
-        raise ArgumentError, <<~ERROR_MESSAGE
-          You must pass a valid aspect ratio to the validator
-          It should either be a named aspect ratio (#{NAMED_ASPECT_RATIOS.join(', ')})
-          Or an aspect ratio like 'is_16_9' (matching /#{ASPECT_RATIO_REGEX.source}/)
-        ERROR_MESSAGE
+      aspect_ratios(options).each do |aspect_ratio|
+        unless NAMED_ASPECT_RATIOS.include?(aspect_ratio) || aspect_ratio =~ ASPECT_RATIO_REGEX
+          raise ArgumentError, invalid_aspect_ratio_message(aspect_ratio)
+        end
       end
+    end
+
+    def invalid_aspect_ratio_message(aspect_ratio)
+      <<~ERROR_MESSAGE
+        You must pass valid content types to the validator
+        '#{aspect_ratio}' is not found in Marcel::EXTENSIONS mimes
+      ERROR_MESSAGE
+    end
+
+    def aspect_ratios(flat_options)
+      (Array.wrap(flat_options[:with]) + Array.wrap(flat_options[:in]))
+    end
+
+    def string_aspect_ratios(flat_options)
+      aspect_ratios(flat_options).map do |aspect_ratio|
+        if NAMED_ASPECT_RATIOS.include?(aspect_ratio)
+          aspect_ratio
+        else
+          aspect_ratio =~ ASPECT_RATIO_REGEX
+          x = ::Regexp.last_match(1).to_i
+          y = ::Regexp.last_match(2).to_i
+
+          "#{x}:#{y}"
+        end
+      end.join(', ')
     end
   end
 end

--- a/lib/active_storage_validations/aspect_ratio_validator.rb
+++ b/lib/active_storage_validations/aspect_ratio_validator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'shared/asv_active_storageable'
+require_relative 'shared/asv_analyzable'
 require_relative 'shared/asv_attachable'
 require_relative 'shared/asv_errorable'
 require_relative 'shared/asv_optionable'
@@ -9,6 +10,7 @@ require_relative 'shared/asv_symbolizable'
 module ActiveStorageValidations
   class AspectRatioValidator < ActiveModel::EachValidator # :nodoc
     include ASVActiveStorageable
+    include ASVAnalyzable
     include ASVAttachable
     include ASVErrorable
     include ASVOptionable

--- a/lib/active_storage_validations/aspect_ratio_validator.rb
+++ b/lib/active_storage_validations/aspect_ratio_validator.rb
@@ -45,35 +45,32 @@ module ActiveStorageValidations
 
       return if image_metadata_missing?(record, attribute, attachable, flat_options, metadata)
 
-      aspect_ratios = aspect_ratios(flat_options).compact
-      errors = add_errors(aspect_ratios, metadata)
-
-      return true if errors.length != aspect_ratios.length
-
-      error = aspect_ratios.length == 1 ? errors.first : :aspect_ratio_invalid
+      @authorized_aspect_ratios = authorized_aspect_ratios(flat_options).compact
+      
+      return true if authorized_aspect_ratio?(record, attribute, attachable, metadata)
 
       errors_options = initialize_error_options(options, attachable)
       errors_options[:aspect_ratio] = string_aspect_ratios(flat_options)
-      add_error(record, attribute, error, **errors_options)
+      add_error(record, attribute, aspect_ratio_error_mapping, **errors_options)
       false
     end
 
-    def add_errors(aspect_ratios, metadata)
-      aspect_ratios.map do |aspect_ratio|
-        aspect_ratio_error(aspect_ratio, metadata)
-      end.compact.uniq
+    def authorized_aspect_ratio?(record, attribute, attachable, metadata)
+      attachable_aspect_ratio_is_authorized = @authorized_aspect_ratios.any? do |authorized_aspect_ratio|
+        case authorized_aspect_ratio
+        when :square then valid_square_aspect_ratio?(metadata)
+        when :portrait then valid_portrait_aspect_ratio?(metadata)
+        when :landscape then valid_landscape_aspect_ratio?(metadata)
+        when ASPECT_RATIO_REGEX then valid_regex_aspect_ratio?(authorized_aspect_ratio, metadata)
+        end
+      end
     end
 
-    def aspect_ratio_error(aspect_ratio, metadata)
-      if aspect_ratio == :square && !valid_square_aspect_ratio?(metadata)
-        :aspect_ratio_not_square
-      elsif aspect_ratio == :portrait && !valid_portrait_aspect_ratio?(metadata)
-        :aspect_ratio_not_portrait
-      elsif aspect_ratio == :landscape && !valid_landscape_aspect_ratio?(metadata)
-        :aspect_ratio_not_landscape
-      elsif ASPECT_RATIO_REGEX.match?(aspect_ratio) && !valid_regex_aspect_ratio?(aspect_ratio, metadata)
-        :aspect_ratio_is_not
-      end
+    def aspect_ratio_error_mapping
+      return :aspect_ratio_invalid unless @authorized_aspect_ratios.length == 1
+
+      aspect_ratio = @authorized_aspect_ratios.first
+      NAMED_ASPECT_RATIOS.include?(aspect_ratio) ? :"aspect_ratio_not_#{aspect_ratio}" : :aspect_ratio_is_not
     end
 
     def image_metadata_missing?(record, attribute, attachable, flat_options, metadata)
@@ -114,7 +111,7 @@ module ActiveStorageValidations
     def ensure_aspect_ratio_validity
       return true if options[:with]&.is_a?(Proc) || options[:in]&.is_a?(Proc)
 
-      aspect_ratios(options).each do |aspect_ratio|
+      authorized_aspect_ratios(options).each do |aspect_ratio|
         unless NAMED_ASPECT_RATIOS.include?(aspect_ratio) || aspect_ratio =~ ASPECT_RATIO_REGEX
           raise ArgumentError, invalid_aspect_ratio_message
         end
@@ -129,12 +126,12 @@ module ActiveStorageValidations
       ERROR_MESSAGE
     end
 
-    def aspect_ratios(flat_options)
+    def authorized_aspect_ratios(flat_options)
       (Array.wrap(flat_options[:with]) + Array.wrap(flat_options[:in]))
     end
 
     def string_aspect_ratios(flat_options)
-      aspect_ratios(flat_options).map do |aspect_ratio|
+      authorized_aspect_ratios(flat_options).map do |aspect_ratio|
         if NAMED_ASPECT_RATIOS.include?(aspect_ratio)
           aspect_ratio
         else

--- a/test/active_storage_validations_test.rb
+++ b/test/active_storage_validations_test.rb
@@ -411,6 +411,8 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     e.proc_ratio_one.attach(image_150x150_file)
     e.ratio_many.attach([image_600x800_file])
     e.proc_ratio_many.attach([image_600x800_file])
+    e.ratio_in.attach(image_150x150_file)
+    e.proc_ratio_in.attach(image_150x150_file)
     e.save!
 
     e = RatioModel.new(name: 'Princess Leia')
@@ -418,6 +420,8 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     e.proc_ratio_one.attach(image_150x150_file)
     e.ratio_many.attach([image_150x150_file])
     e.proc_ratio_many.attach([image_150x150_file])
+    e.ratio_in.attach(image_150x150_file)
+    e.proc_ratio_in.attach(image_150x150_file)
     e.save
     assert !e.valid?
     assert_equal e.errors.full_messages, ["Ratio many must be a portrait image", "Proc ratio many must be a portrait image"]
@@ -429,6 +433,8 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     e.proc_ratio_many.attach([image_600x800_file])
     e.image1.attach(image_150x150_file)
     e.proc_image1.attach(image_150x150_file)
+    e.ratio_in.attach(image_150x150_file)
+    e.proc_ratio_in.attach(image_150x150_file)
     assert !e.valid?
     assert_equal e.errors.full_messages, ["Image1 must have an aspect ratio of 16:9", 'Proc image1 must have an aspect ratio of 16:9']
 
@@ -439,7 +445,33 @@ class ActiveStorageValidations::Test < ActiveSupport::TestCase
     e.proc_ratio_many.attach([image_600x800_file])
     e.image1.attach(image_1920x1080_file)
     e.proc_image1.attach(image_1920x1080_file)
+    e.ratio_in.attach(image_150x150_file)
+    e.proc_ratio_in.attach(image_150x150_file)
     assert !e.valid?
     assert_equal e.errors.full_messages, ["Ratio one is not a valid image", 'Proc ratio one is not a valid image']
+
+    e = RatioModel.new(name: 'Princess Leia')
+    e.ratio_one.attach(image_150x150_file)
+    e.proc_ratio_one.attach(image_150x150_file)
+    e.ratio_many.attach([image_600x800_file])
+    e.proc_ratio_many.attach([image_600x800_file])
+    e.ratio_in.attach(image_1920x1080_file)
+    e.proc_ratio_in.attach(image_1920x1080_file)
+    assert !e.valid?
+    assert_equal e.errors.details, ratio_in: [
+      {
+        error: :aspect_ratio_invalid,
+        validator_type: :aspect_ratio,
+        filename: 'image_1920x1080_file.png',
+        aspect_ratio: 'square, portrait'
+      }
+    ], proc_ratio_in: [
+     {
+       error: :aspect_ratio_invalid,
+       validator_type: :aspect_ratio,
+       filename: 'image_1920x1080_file.png',
+       aspect_ratio: 'square, portrait'
+     }
+    ] 
   end
 end

--- a/test/dummy/app/models/aspect_ratio/validator/check.rb
+++ b/test/dummy/app/models/aspect_ratio/validator/check.rb
@@ -23,4 +23,9 @@ class AspectRatio::Validator::Check < ApplicationRecord
 
   has_one_attached :with_invalid_image_file
   validates :with_invalid_image_file, aspect_ratio: :square
+
+  has_one_attached :in_aspect_ratios
+  has_one_attached :in_aspect_ratios_proc
+  validates :in_aspect_ratios, aspect_ratio: %i(square portrait is_16_9)
+  validates :in_aspect_ratios_proc, aspect_ratio: -> (record) { %i(square portrait is_16_9) }
 end

--- a/test/dummy/app/models/ratio_model.rb
+++ b/test/dummy/app/models/ratio_model.rb
@@ -10,9 +10,12 @@ class RatioModel < ApplicationRecord
   has_one_attached :landscape_image
   has_one_attached :squared_image
   has_one_attached :widescreen_image
+  has_one_attached :ratio_in
+  has_one_attached :proc_ratio_in
 
   validates :ratio_one, attached: true, aspect_ratio: :square
   validates :ratio_many, attached: true, aspect_ratio: :portrait # portrait
+  validates :ratio_in, attached: true, aspect_ratio: { in: [:square, :portrait] }
   validates :image1, aspect_ratio: :is_16_9 # portrait
 
   validates :portrait_image, aspect_ratio: :portrait
@@ -24,5 +27,6 @@ class RatioModel < ApplicationRecord
   #validates :ratio_many, attached: true, aspect_ratio: :portrait # portrait
   validates :proc_ratio_one, attached: true, aspect_ratio: -> (record) {:square}
   validates :proc_ratio_many, attached: true, aspect_ratio: -> (record) {:portrait} # portrait
+  validates :proc_ratio_in, attached: true, aspect_ratio: -> (record) {[:square, :portrait]}
   validates :proc_image1, aspect_ratio: -> (record) {:is_16_9} # portrait
 end

--- a/test/validators/aspect_ratio_validator_test.rb
+++ b/test/validators/aspect_ratio_validator_test.rb
@@ -204,23 +204,15 @@ describe ActiveStorageValidations::AspectRatioValidator do
       end
     end
 
-    describe 'Edge cases' do
-      describe 'when the passed file is not a valid image' do
+    describe "Edge cases" do
+      describe "when the passed file is not a valid image" do
+        subject { model.public_send(attribute).attach(empty_io_file) and model }
+
         let(:attribute) { :with_invalid_image_file }
-
-        describe 'when provided with a not allowed aspect_ratio file' do
-          subject { model.public_send(attribute).attach(not_allowed_file) and model }
-
-          let(:not_allowed_file) { empty_io_file }
-          let(:error_options) do
-            {
-              filename: not_allowed_file[:filename]
-            }
-          end
-
-          it { is_expected_not_to_be_valid }
-          it { is_expected_to_have_error_message("image_metadata_missing", error_options: error_options) }
-          it { is_expected_to_have_error_options(error_options) }
+        let(:error_options) do
+          {
+            filename: empty_io_file[:filename]
+          }
         end
 
         it { is_expected_not_to_be_valid }

--- a/test/validators/aspect_ratio_validator_test.rb
+++ b/test/validators/aspect_ratio_validator_test.rb
@@ -89,16 +89,16 @@ describe ActiveStorageValidations::AspectRatioValidator do
 
     let(:model) { validator_test_class::Check.new(params) }
 
-    describe ":with" do
+    describe ':with' do
       # validates :with_named_square, aspect_ratio: :square
       # validates :with_named_portrait, aspect_ratio: :portrait
       # validates :with_named_landscape, aspect_ratio: :landscape
       # validates :with_named_square_proc, aspect_ratio: -> (record) { :square }
       # validates :with_named_portrait_proc, aspect_ratio: -> (record) { :portrait }
       # validates :with_named_landscape_proc, aspect_ratio: -> (record) { :landscape }
-      %w(value proc).each do |value_type|
-        describe "named aspect_ratio" do
-          %i(square portrait landscape).each do |named_aspect_ratio|
+      %w[value proc].each do |value_type|
+        describe 'named aspect_ratio' do
+          %i[square portrait landscape].each do |named_aspect_ratio|
             describe ":#{named_aspect_ratio}" do
               let(:attribute) { :"with_#{named_aspect_ratio}#{'_proc' if value_type == 'proc'}" }
 
@@ -128,7 +128,7 @@ describe ActiveStorageValidations::AspectRatioValidator do
                 end
                 let(:error_options) do
                   {
-                    aspect_ratio: named_aspect_ratio,
+                    aspect_ratio: named_aspect_ratio.to_s,
                     filename: not_allowed_file[:filename]
                   }
                 end
@@ -141,7 +141,7 @@ describe ActiveStorageValidations::AspectRatioValidator do
           end
         end
 
-        describe "regex aspect_ratio" do
+        describe 'regex aspect_ratio' do
           let(:attribute) { :"with_regex#{'_proc' if value_type == 'proc'}" }
 
           describe 'when provided with an allowed aspect_ratio file' do
@@ -158,28 +158,69 @@ describe ActiveStorageValidations::AspectRatioValidator do
             let(:not_allowed_file) { is_4_3_image_file }
             let(:error_options) do
               {
-                aspect_ratio: "16:9",
+                aspect_ratio: '16:9',
                 filename: not_allowed_file[:filename]
               }
             end
 
             it { is_expected_not_to_be_valid }
-            it { is_expected_to_have_error_message("aspect_ratio_is_not", error_options: error_options) }
+            it { is_expected_to_have_error_message('aspect_ratio_is_not', error_options: error_options) }
             it { is_expected_to_have_error_options(error_options) }
           end
         end
       end
     end
 
-    describe "Edge cases" do
-      describe "when the passed file is not a valid image" do
-        subject { model.public_send(attribute).attach(empty_io_file) and model }
+    describe ':in' do
+      %w[value proc].each do |value_type|
+        describe value_type do
+          let(:attribute) { :"in_aspect_ratios#{'_proc' if value_type == 'proc'}" }
 
+          describe 'when provided with an allowed aspect_ratio file' do
+            subject { model.public_send(attribute).attach(allowed_file) and model }
+
+            let(:allowed_file) { [square_image_file, portrait_image_file, is_16_9_image_file].sample }
+
+            it { is_expected_to_be_valid }
+          end
+
+          describe 'when provided with a not allowed aspect_ratio file' do
+            subject { model.public_send(attribute).attach(not_allowed_file) and model }
+
+            let(:not_allowed_file) { is_4_3_image_file }
+
+            let(:error_options) do
+              {
+                aspect_ratio: 'square, portrait, 16:9',
+                filename: not_allowed_file[:filename]
+              }
+            end
+
+            it { is_expected_not_to_be_valid }
+            it { is_expected_to_have_error_message('aspect_ratio_invalid', error_options: error_options) }
+            it { is_expected_to_have_error_options(error_options) }
+          end
+        end
+      end
+    end
+
+    describe 'Edge cases' do
+      describe 'when the passed file is not a valid image' do
         let(:attribute) { :with_invalid_image_file }
-        let(:error_options) do
-          {
-            filename: empty_io_file[:filename]
-          }
+
+        describe 'when provided with a not allowed aspect_ratio file' do
+          subject { model.public_send(attribute).attach(not_allowed_file) and model }
+
+          let(:not_allowed_file) { empty_io_file }
+          let(:error_options) do
+            {
+              filename: not_allowed_file[:filename]
+            }
+          end
+
+          it { is_expected_not_to_be_valid }
+          it { is_expected_to_have_error_message('image_metadata_missing', error_options: error_options) }
+          it { is_expected_to_have_error_options(error_options) }
         end
 
         it { is_expected_not_to_be_valid }

--- a/test/validators/aspect_ratio_validator_test.rb
+++ b/test/validators/aspect_ratio_validator_test.rb
@@ -89,16 +89,16 @@ describe ActiveStorageValidations::AspectRatioValidator do
 
     let(:model) { validator_test_class::Check.new(params) }
 
-    describe ':with' do
+    describe ":with" do
       # validates :with_named_square, aspect_ratio: :square
       # validates :with_named_portrait, aspect_ratio: :portrait
       # validates :with_named_landscape, aspect_ratio: :landscape
       # validates :with_named_square_proc, aspect_ratio: -> (record) { :square }
       # validates :with_named_portrait_proc, aspect_ratio: -> (record) { :portrait }
       # validates :with_named_landscape_proc, aspect_ratio: -> (record) { :landscape }
-      %w[value proc].each do |value_type|
-        describe 'named aspect_ratio' do
-          %i[square portrait landscape].each do |named_aspect_ratio|
+      %w(value proc).each do |value_type|
+        describe "named aspect_ratio" do
+          %i(square portrait landscape).each do |named_aspect_ratio|
             describe ":#{named_aspect_ratio}" do
               let(:attribute) { :"with_#{named_aspect_ratio}#{'_proc' if value_type == 'proc'}" }
 
@@ -141,7 +141,7 @@ describe ActiveStorageValidations::AspectRatioValidator do
           end
         end
 
-        describe 'regex aspect_ratio' do
+        describe "regex aspect_ratio" do
           let(:attribute) { :"with_regex#{'_proc' if value_type == 'proc'}" }
 
           describe 'when provided with an allowed aspect_ratio file' do
@@ -158,13 +158,13 @@ describe ActiveStorageValidations::AspectRatioValidator do
             let(:not_allowed_file) { is_4_3_image_file }
             let(:error_options) do
               {
-                aspect_ratio: '16:9',
+                aspect_ratio: "16:9",
                 filename: not_allowed_file[:filename]
               }
             end
 
             it { is_expected_not_to_be_valid }
-            it { is_expected_to_have_error_message('aspect_ratio_is_not', error_options: error_options) }
+            it { is_expected_to_have_error_message("aspect_ratio_is_not", error_options: error_options) }
             it { is_expected_to_have_error_options(error_options) }
           end
         end
@@ -219,7 +219,7 @@ describe ActiveStorageValidations::AspectRatioValidator do
           end
 
           it { is_expected_not_to_be_valid }
-          it { is_expected_to_have_error_message('image_metadata_missing', error_options: error_options) }
+          it { is_expected_to_have_error_message("image_metadata_missing", error_options: error_options) }
           it { is_expected_to_have_error_options(error_options) }
         end
 


### PR DESCRIPTION
Fixes #230 

Add support for validating multiple aspect ratios, as done for content types, like:
```ruby
validates :avatar, aspect_ratio: [:square, :portrait, :is_16_9]
```