### PR TITLE
Require marcel

### DIFF
--- a/lib/active_storage_validations/marcel_extensor.rb
+++ b/lib/active_storage_validations/marcel_extensor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "marcel"
+
 Marcel::MimeType.extend "application/x-rar-compressed", parents: %(application/x-rar)
 Marcel::MimeType.extend "audio/x-hx-aac-adts", parents: %(audio/x-aac)
 Marcel::MimeType.extend "audio/x-m4a", parents: %(audio/mp4)


### PR DESCRIPTION
Saw this error in CI and realized nothing was requiring `marcel`. Things might have been working because ActiveStorage might have loaded it before this gem. But in general, we should require where we use it.

```
/usr/local/bundle/ruby/3.3.0/gems/active_storage_validations-1.3.4/lib/active_storage_validations/marcel_extensor.rb:3:in `<top (required)>': uninitialized constant Marcel (NameError)
  |  
  | Marcel::MimeType.extend "application/x-rar-compressed", parents: %(application/x-rar)
  | ^^^^^^
  | Did you mean?  Arel
  | from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
  | from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
  | from /usr/local/bundle/ruby/3.3.0/gems/active_storage_validations-1.3.4/lib/active_storage_validations.rb:17:in `<top (required)>'
  | from <internal:/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
  | from <internal:/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
  | from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
  | from /usr/local/lib/ruby/site_ruby/3.3.0/bundler/runtime.rb:60:in `block (2 levels) in require'
  | from /usr/local/lib/ruby/site_ruby/3.3.0/bundler/runtime.rb:55:in `each'
  | from /usr/local/lib/ruby/site_ruby/3.3.0/bundler/runtime.rb:55:in `block in require'
  | from /usr/local/lib/ruby/site_ruby/3.3.0/bundler/runtime.rb:44:in `each'
  | from /usr/local/lib/ruby/site_ruby/3.3.0/bundler/runtime.rb:44:in `require'
  | from /usr/local/lib/ruby/site_ruby/3.3.0/bundler.rb:212:in `require'
  | from /usr/local/bundle/ruby/3.3.0/gems/sidekiq-ent-7.1.2/bin/sidekiqswarm:40:in `<top (required)>'
  | from bin/sidekiqswarm:27:in `load'
  | from bin/sidekiqswarm:27:in `<main>'
 ```