### PR TITLE
Refactor require-ing for supported analyzers

### DIFF
--- a/lib/active_storage_validations/analyzer/image_analyzer.rb
+++ b/lib/active_storage_validations/analyzer/image_analyzer.rb
@@ -12,7 +12,11 @@ module ActiveStorageValidations
   #   ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick.new(attachable).metadata
   #   # => { width: 4104, height: 2736 }
   class Analyzer::ImageAnalyzer < Analyzer
+    @@supported_analyzers = {}
+
     def metadata
+      return {} unless analyzer_supported?
+
       read_image do |image|
         if rotated_image?(image)
           { width: image.height, height: image.width }
@@ -62,6 +66,14 @@ module ActiveStorageValidations
       image_from_path(tempfile.path)
     end
 
+    def analyzer_supported?
+      if @@supported_analyzers.key?(self)
+        @@supported_analyzers.fetch(self)
+      else
+        @@supported_analyzers[self] = supported?
+      end
+    end
+
     def read_image
       raise NotImplementedError
     end
@@ -71,6 +83,10 @@ module ActiveStorageValidations
     end
 
     def rotated_image?(image)
+      raise NotImplementedError
+    end
+
+    def supported?
       raise NotImplementedError
     end
   end

--- a/lib/active_storage_validations/analyzer/image_analyzer/image_magick.rb
+++ b/lib/active_storage_validations/analyzer/image_analyzer/image_magick.rb
@@ -9,13 +9,6 @@ module ActiveStorageValidations
     private
 
     def read_image
-      begin
-        require "mini_magick" unless defined?(MiniMagick)
-      rescue LoadError
-        logger.info "Skipping image analysis because the mini_magick gem isn't installed"
-        return {}
-      end
-
       Tempfile.create(binmode: true) do |tempfile|
         begin
           if image(tempfile).valid?
@@ -41,6 +34,14 @@ module ActiveStorageValidations
 
     def rotated_image?(image)
       %w[ RightTop LeftBottom TopRight BottomLeft ].include?(image["%[orientation]"])
+    end
+
+    def supported?
+      require "mini_magick"
+      true
+    rescue LoadError
+      logger.info "Skipping image analysis because the mini_magick gem isn't installed"
+      false
     end
   end
 end

--- a/lib/active_storage_validations/analyzer/image_analyzer/vips.rb
+++ b/lib/active_storage_validations/analyzer/image_analyzer/vips.rb
@@ -8,13 +8,6 @@ module ActiveStorageValidations
     private
 
     def read_image
-      begin
-        require "vips" unless defined?(::Vips)
-      rescue LoadError
-        logger.info "Skipping image analysis because the ruby-vips gem isn't installed"
-        return {}
-      end
-
       Tempfile.create(binmode: true) do |tempfile|
         begin
           if image(tempfile)
@@ -45,6 +38,13 @@ module ActiveStorageValidations
           nil
         end
       end
+    end
+
+    def supported?
+      require "vips"
+      true
+    rescue LoadError
+      false
     end
 
     ROTATIONS = /Right-top|Left-bottom|Top-right|Bottom-left/

--- a/lib/active_storage_validations/analyzer/image_analyzer/vips.rb
+++ b/lib/active_storage_validations/analyzer/image_analyzer/vips.rb
@@ -44,6 +44,7 @@ module ActiveStorageValidations
       require "vips"
       true
     rescue LoadError
+      logger.info "Skipping image analysis because the ruby-vips gem isn't installed"
       false
     end
 


### PR DESCRIPTION
From the discussion in https://github.com/igorkasyanchuk/active_storage_validations/pull/326, I thought it'd be a fun exercise to see what it would look like to extract support detection. This PR does the follow:
- Adds a new abstract `supported?` method that allows analyzers to do whatever to determine whether or not it's supported. This usually means loading the library and catching the load error.
- The support list is held (and cached) in a class attribute (Hash) for quick, subsequent lookups.
- This also changes `require "whatever" unless defined?(Whatever)` to just `require "whatever"` since it safeguards against things that happen to define `Whatever` without loading the library/gem.