### PR TITLE
fix: Error messages for PDF validation

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -58,6 +58,6 @@ de:
       pages_not_less_than: "Die Seitenanzahl muss kleiner als %{max} sein (die aktuelle Seitenanzahl beträgt %{pages})."
       pages_not_less_than_or_equal_to: "Die Seitenanzahl muss kleiner oder gleich %{max} sein (die aktuelle Seitenanzahl beträgt %{pages})."
       pages_not_greater_than: "Die Seitenanzahl muss größer als %{min} sein (die aktuelle Seitenanzahl beträgt %{pages})."
-      pages_not_greater_than_or_qual_to: "Die Seitenanzahl muss größer oder gleich %{min} sein (die aktuelle Seitenanzahl beträgt %{pages})."
+      pages_not_greater_than_or_equal_to: "Die Seitenanzahl muss größer oder gleich %{min} sein (die aktuelle Seitenanzahl beträgt %{pages})."
       pages_not_between: "Die Seitenanzahl muss zwischen %{min} und %{max} liegen (die aktuelle Seitenanzahl beträgt %{pages})."
-      pages_not_qual_to: "Die Seitenanzahl muss gleich %{exact} sein (die aktuelle Seitenanzahl beträgt %{pages})."
+      pages_not_equal_to: "Die Seitenanzahl muss gleich %{exact} sein (die aktuelle Seitenanzahl beträgt %{pages})."


### PR DESCRIPTION
This fixes the copy&paste typos from #374, resulting in incorrect locale keys for error messages in German for PDF pages validations.