### PR TITLE
Make PDF analyzer handle decimal dimensions

### DIFF
--- a/lib/active_storage_validations/analyzer/pdf_analyzer.rb
+++ b/lib/active_storage_validations/analyzer/pdf_analyzer.rb
@@ -75,11 +75,11 @@ module ActiveStorageValidations
     end
 
     def width
-      @media["page_size"].scan(/\d+/)[0].to_i
+      @media["page_size"].scan(/\d+\.?\d?/)[0].to_i
     end
 
     def height
-      @media["page_size"].scan(/\d+/)[1].to_i
+      @media["page_size"].scan(/\d+\.?\d?/)[1].to_i
     end
 
     def pages

--- a/test/analyzers/shared_examples/works_fine_with_2_pages_pdf.rb
+++ b/test/analyzers/shared_examples/works_fine_with_2_pages_pdf.rb
@@ -20,5 +20,23 @@ module WorksFineWith2PagesPdf
         assert_equal(expected_metadata, subject)
       end
     end
+
+    describe "working with a pdf with decimal dimensions" do
+      subject { analyzer.metadata }
+
+      let(:attachable) do
+        {
+          io: File.open(Rails.root.join("public", "pdf_123.4x200.7.pdf")),
+          filename: "pdf_123.4x200.7.pdf",
+          content_type: "application/pdf"
+        }
+      end
+
+      let(:expected_metadata) { { width: 123, height: 200, pages: 1 } }
+
+      it "correctly reports decimal dimensions" do
+        assert_equal(expected_metadata, subject)
+      end
+    end
   end
 end

--- a/test/dummy/public/pdf_123.4x200.7.pdf
+++ b/test/dummy/public/pdf_123.4x200.7.pdf
@@ -1,0 +1,108 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Pages 3 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<< /Count 1
+/Kids [5 0 R]
+/Type /Pages
+>>
+endobj
+4 0 obj
+<< /Length 344
+>>
+stream
+q
+
+BT
+36.0 156.084 Td
+/F1.0 12 Tf
+[<48656c6c6f>] TJ
+ET
+
+
+BT
+36.0 142.212 Td
+/F1.0 12 Tf
+[<5044462077697468>] TJ
+ET
+
+
+BT
+36.0 128.34 Td
+/F1.0 12 Tf
+[<646563696d616c>] TJ
+ET
+
+
+BT
+36.0 114.468 Td
+/F1.0 12 Tf
+[<706978> 30 <656c>] TJ
+ET
+
+
+BT
+36.0 100.596 Td
+/F1.0 12 Tf
+[<64696d656e73696f>] TJ
+ET
+
+
+BT
+36.0 86.724 Td
+/F1.0 12 Tf
+[<6e7321>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /ArtBox [0 0 123.4 200.7]
+/BleedBox [0 0 123.4 200.7]
+/Contents 4 0 R
+/CropBox [0 0 123.4 200.7]
+/MediaBox [0 0 123.4 200.7]
+/Parent 3 0 R
+/Resources << /Font << /F1.0 6 0 R
+>>
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+/TrimBox [0 0 123.4 200.7]
+/Type /Page
+>>
+endobj
+6 0 obj
+<< /BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000610 00000 n 
+0000000896 00000 n 
+trailer
+<< /Info 1 0 R
+/Root 2 0 R
+/Size 7
+>>
+startxref
+993
+%%EOF


### PR DESCRIPTION
PDFs are often generated based on print sizes in inches and centimeters. This can result in decimal pixel or point dimensions. This change updates the PdfAnalyzer to return the correct integer dimensions for such PDFs.