### PR TITLE
feat: include content_types in the file-field accept attribute

### DIFF
--- a/lib/active_storage_validations.rb
+++ b/lib/active_storage_validations.rb
@@ -26,5 +26,6 @@ require "active_storage_validations/size_validator"
 require "active_storage_validations/total_size_validator"
 require "active_storage_validations/pages_validator"
 
+require "active_storage_validations/form_builder"
 require "active_storage_validations/engine"
 require "active_storage_validations/railtie"

--- a/lib/active_storage_validations/form_builder.rb
+++ b/lib/active_storage_validations/form_builder.rb
@@ -28,6 +28,9 @@ module ActiveStorageValidations
             type.include?("/") ? type : Marcel::MimeType.for(declared_type: type, extension: type)
           when Symbol
             Marcel::MimeType.for(declared_type: type.to_s, extension: type.to_s)
+          when Regexp
+            match = type.source.match(/\A\\A([a-z]+)\\/\\.\\*\\z\z/)
+            "#{match[1]}/*" if match
           end
         end
       end.uniq

--- a/lib/active_storage_validations/form_builder.rb
+++ b/lib/active_storage_validations/form_builder.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module ActiveStorageValidations
+  module FormBuilder
+    def file_field(method, options = {})
+      if options[:accept].blank?
+        accept = inferred_accept_types(method)
+        options[:accept] = accept.join(",") if accept.any?
+      end
+
+      super(method, options)
+    end
+
+    private
+
+    def inferred_accept_types(method)
+      return [] unless @object.class.respond_to?(:validators_on)
+
+      content_type_validators = @object.class.validators_on(method).select do |v|
+        v.is_a?(ActiveStorageValidations::ContentTypeValidator)
+      end
+
+      content_type_validators.flat_map do |validator|
+        types = Array(validator.options[:with]) + Array(validator.options[:in])
+        types.filter_map do |type|
+          case type
+          when String
+            type.include?("/") ? type : Marcel::MimeType.for(declared_type: type, extension: type)
+          when Symbol
+            Marcel::MimeType.for(declared_type: type.to_s, extension: type.to_s)
+          end
+        end
+      end.uniq
+    end
+  end
+end

--- a/lib/active_storage_validations/form_builder.rb
+++ b/lib/active_storage_validations/form_builder.rb
@@ -29,7 +29,7 @@ module ActiveStorageValidations
           when Symbol
             Marcel::MimeType.for(declared_type: type.to_s, extension: type.to_s)
           when Regexp
-            match = type.source.match(/\A\\A([a-z]+)\\/\\.\\*\\z\z/)
+            match = type.source.match(%r{\A\\A([a-z]+)\\/\.\*\\z\z})
             "#{match[1]}/*" if match
           end
         end

--- a/lib/active_storage_validations/form_builder.rb
+++ b/lib/active_storage_validations/form_builder.rb
@@ -29,7 +29,7 @@ module ActiveStorageValidations
           when Symbol
             Marcel::MimeType.for(declared_type: type.to_s, extension: type.to_s)
           when Regexp
-            match = type.source.match(%r{\A\\A([a-z]+)\\/\.\*\\z\z})
+            match = type.source.match(%r{\A\\A([a-z]+)/\.\*\\z\z})
             "#{match[1]}/*" if match
           end
         end

--- a/lib/active_storage_validations/railtie.rb
+++ b/lib/active_storage_validations/railtie.rb
@@ -11,6 +11,12 @@ module ActiveStorageValidations
       end
     end
 
+    initializer "active_storage_validations.form_builder" do
+      ActiveSupport.on_load(:action_view) do
+        ActionView::Helpers::FormBuilder.prepend(ActiveStorageValidations::FormBuilder)
+      end
+    end
+
     initializer "active_storage_validations.extend_active_storage_blob" do
       ActiveSupport.on_load(:active_storage_blob) do
         include ActiveStorageValidations::ASVBlobMetadatable

--- a/test/dummy/app/models/form_builder.rb
+++ b/test/dummy/app/models/form_builder.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module FormBuilder
+  def self.table_name_prefix
+    "form_builder_"
+  end
+end

--- a/test/dummy/app/models/form_builder/check.rb
+++ b/test/dummy/app/models/form_builder/check.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: form_builder_checks
+#
+#  id         :integer          not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class FormBuilder::Check < ApplicationRecord
+  has_one_attached :with_symbol
+  validates :with_symbol, content_type: :png
+
+  has_one_attached :in_array
+  validates :in_array, content_type: [:png, :gif]
+
+  has_one_attached :with_string_mime
+  validates :with_string_mime, content_type: "image/png"
+
+  has_one_attached :with_proc
+  validates :with_proc, content_type: ->(record) { :png }
+
+  has_one_attached :with_regex
+  validates :with_regex, content_type: /\Aimage\/.*\z/
+
+  has_one_attached :no_content_type_validator
+  validates :no_content_type_validator, attached: true
+
+  has_one_attached :no_validator
+end

--- a/test/dummy/app/models/form_builder/check.rb
+++ b/test/dummy/app/models/form_builder/check.rb
@@ -14,7 +14,7 @@ class FormBuilder::Check < ApplicationRecord
   validates :with_symbol, content_type: :png
 
   has_one_attached :in_array
-  validates :in_array, content_type: [:png, :gif]
+  validates :in_array, content_type: [ :png, :gif ]
 
   has_one_attached :with_string_mime
   validates :with_string_mime, content_type: "image/png"

--- a/test/dummy/app/models/form_builder/check.rb
+++ b/test/dummy/app/models/form_builder/check.rb
@@ -25,6 +25,9 @@ class FormBuilder::Check < ApplicationRecord
   has_one_attached :with_regex
   validates :with_regex, content_type: /\Aimage\/.*\z/
 
+  has_one_attached :with_non_matching_regex
+  validates :with_non_matching_regex, content_type: /\Aimage\/(png|gif)\z/
+
   has_one_attached :no_content_type_validator
   validates :no_content_type_validator, attached: true
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -212,6 +212,11 @@ ActiveRecord::Schema.define do
     t.datetime :updated_at, precision: 6, null: false
   end
 
+  create_table :form_builder_checks, force: :cascade do |t|
+    t.datetime :created_at, null: false
+    t.datetime :updated_at, null: false
+  end
+
   create_table :users, force: :cascade do |t|
     t.string :name
     t.datetime :created_at, null: false

--- a/test/form_builder/form_builder_test.rb
+++ b/test/form_builder/form_builder_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe ActiveStorageValidations::FormBuilder do
+  let(:model) { FormBuilder::Check.new }
+  let(:builder) { ActionView::Helpers::FormBuilder.new(:check, model, ActionView::Base.empty, {}) }
+
+  describe "file_field with content_type validator" do
+    it "auto-sets accept from :with symbol option" do
+      html = builder.file_field(:with_symbol)
+      assert_includes html, 'accept="image/png"'
+    end
+
+    it "auto-sets accept from :in array option" do
+      html = builder.file_field(:in_array)
+      assert_includes html, "image/png"
+      assert_includes html, "image/gif"
+    end
+
+    it "auto-sets accept from string MIME type" do
+      html = builder.file_field(:with_string_mime)
+      assert_includes html, 'accept="image/png"'
+    end
+
+    it "does not override explicit accept option" do
+      html = builder.file_field(:with_symbol, accept: "image/jpeg")
+      assert_includes html, 'accept="image/jpeg"'
+      refute_includes html, "image/png"
+    end
+
+    it "handles models without content_type validators" do
+      html = builder.file_field(:no_content_type_validator)
+      refute_includes html, "accept="
+    end
+
+    it "handles attachments with no validators at all" do
+      html = builder.file_field(:no_validator)
+      refute_includes html, "accept="
+    end
+
+    it "skips Proc options gracefully" do
+      html = builder.file_field(:with_proc)
+      refute_includes html, "accept="
+    end
+
+    it "skips Regexp options gracefully" do
+      html = builder.file_field(:with_regex)
+      refute_includes html, "accept="
+    end
+  end
+end

--- a/test/form_builder/form_builder_test.rb
+++ b/test/form_builder/form_builder_test.rb
@@ -44,8 +44,13 @@ describe ActiveStorageValidations::FormBuilder do
       refute_includes html, "accept="
     end
 
-    it "skips Regexp options gracefully" do
+    it "auto-sets accept from Regexp content type" do
       html = builder.file_field(:with_regex)
+      assert_includes html, 'accept="image/*"'
+    end
+
+    it "skips non-matching Regexp options gracefully" do
+      html = builder.file_field(:with_non_matching_regex)
       refute_includes html, "accept="
     end
   end


### PR DESCRIPTION
include content_types in the file-field accept attribute to also validate on the front-end.

Define in model:
`
validates :logo, content_type: %w[image/jpeg image/png image/gif image/webp]
`

Call form_builder:
`<%= form.file_field :logo %>`

Automatically include content_types in accept HTML attribute:
`<input class="form-control" accept="image/jpeg,image/png,image/gif,image/webp" type="file" name="tenant[logo]" id="tenant_logo">`