### PR TITLE
Fix validation of multiple new attachables with nil blob ids

### DIFF
--- a/lib/active_storage_validations/shared/asv_attachable.rb
+++ b/lib/active_storage_validations/shared/asv_attachable.rb
@@ -44,12 +44,18 @@ module ActiveStorageValidations
       return to_enum(:attachables_and_blobs, record, attribute) if changes.blank? || !block_given?
 
       if changes.is_a?(ActiveStorage::Attached::Changes::CreateMany)
-        changes.attachables.zip(changes.blobs).uniq { |_, blob| blob&.id }.each do |attachable, blob|
+        changes.attachables.zip(changes.blobs).uniq { |attachable, blob| attachable_blob_key(attachable, blob) }.each do |attachable, blob|
           yield attachable, blob
         end
       else
         yield changes.is_a?(ActiveStorage::Attached::Changes::CreateOne) ? changes.attachable : changes.blob, changes.blob
       end
+    end
+
+    def attachable_blob_key(attachable, blob)
+      return [ :blob_id, blob.id ] if blob&.id
+
+      [ :attachable, attachable.object_id ]
     end
 
     def changes_for(record, attribute)

--- a/test/validators/shared_examples/asv_attachable.rb
+++ b/test/validators/shared_examples/asv_attachable.rb
@@ -85,5 +85,15 @@ module ASVAttachable
         assert(subject.invalid?)
       end
     end
+
+    describe "when multiple new files are attached at once" do
+      it "still reports errors for the invalid file when another new file is valid" do
+        next if file_not_matching_requirements.nil? # validators like :limit or :attached don't apply here
+
+        subject.asv_attachables.attach([ file_matching_requirements, file_not_matching_requirements ])
+
+        assert(subject.invalid?)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Fix `CreateMany` attachable deduplication so persisted blobs are deduplicated by `blob.id`, while newly attached unsaved files remain distinct.
- Add a shared regression test covering multiple new files where one file is valid and another is invalid.
- Preserve the intended duplicate signed_id behavior from #421 for persisted blobs.

## Test plan
- `BUNDLE_GEMFILE=gemfiles/rails_8_1.gemfile bundle exec ruby -Itest test/validators/content_type_validator_test.rb -n "/multiple new files/"`
- Ran the same `-n "/multiple new files/"` filter across the validator files that include the shared ASVAttachable behavior.